### PR TITLE
Bugfix/cmp-442/catalog-issue: fix catalog and edc version

### DIFF
--- a/charts/digital-product-pass/README.md
+++ b/charts/digital-product-pass/README.md
@@ -1,0 +1,20 @@
+# Digital Product Passport Helm Chart
+
+This helm release contains two helm deployments: digital product pass consumer frontend and backend with their default values.
+
+## Prerequisites:
+
+- Kubernetes 1.24+
+- Helm 3.9.0+
+
+## TL;DR
+```bash
+# Install a new helm release
+helm install digital-product-passport ./charts/digital-product-passport --values=values.yaml
+
+# Listing helm releases
+helm list
+
+# Uninstall helm chart
+helm uninstall digital-product-passport
+```

--- a/deployment/helm/edc-consumer/Chart.lock
+++ b/deployment/helm/edc-consumer/Chart.lock
@@ -1,29 +1,15 @@
-# Copyright 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
-# 
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-# 
-#     http://www.apache.org/licenses/LICENSE-2.0
-# 
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 dependencies:
 - name: edc-controlplane
   repository: https://catenax-ng.github.io/product-edc
-  version: 0.2.0
+  version: 0.1.6
 - name: edc-dataplane
   repository: https://catenax-ng.github.io/product-edc
-  version: 0.2.0
+  version: 0.1.6
 - name: backend-service
   repository: file://backend-service
   version: 0.0.6
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 12.1.5
-digest: sha256:87eff1089f7e2e6951e16c679f027368301e2ee7c96d2c0317873264aa513507
-generated: "2022-12-28T14:40:43.9830205+01:00"
+digest: sha256:ecbdb77968205912ac5c9fa3badf285821e0e00b57ea05993d327442114863bc
+generated: "2023-02-23T10:37:31.1786728+01:00"

--- a/deployment/helm/edc-consumer/Chart.yaml
+++ b/deployment/helm/edc-consumer/Chart.yaml
@@ -22,12 +22,12 @@ appVersion: "0.4.2"
 dependencies:
   - name: edc-controlplane
     alias: controlplane
-    version: "0.2.0"
+    version: "0.1.6"
     repository: https://catenax-ng.github.io/product-edc
     condition: controlplane.enabled
   - name: edc-dataplane
     alias: dataplane
-    version: "0.2.0"
+    version: "0.1.6"
     repository: https://catenax-ng.github.io/product-edc
     condition: dataplane.enabled
   - name: backend-service

--- a/deployment/helm/edc-consumer/values-dev.yaml
+++ b/deployment/helm/edc-consumer/values-dev.yaml
@@ -36,7 +36,7 @@ postgres:
 dataplane:
   image:
     repository: ghcr.io/catenax-ng/product-edc/edc-dataplane-hashicorp-vault
-    tag: 0.2.0
+    tag: 0.1.6
     pullPolicy: IfNotPresent
   envSecretName: "consumer-dataplane-secret"
   fullnameOverride: "materialpass-edc-dataplane"
@@ -102,7 +102,7 @@ controlplane:
   fullnameOverride: "materialpass-edc-controlplane"
   image:
     repository: ghcr.io/catenax-ng/product-edc/edc-controlplane-postgresql-hashicorp-vault
-    tag: 0.2.0
+    tag: 0.1.6
     pullPolicy: IfNotPresent
   envSecretName: "consumer-controlplane-secret"
   edc:

--- a/deployment/helm/edc-consumer/values-int.yaml
+++ b/deployment/helm/edc-consumer/values-int.yaml
@@ -36,7 +36,7 @@ postgres:
 dataplane:
   image:
     repository: ghcr.io/catenax-ng/product-edc/edc-dataplane-hashicorp-vault
-    tag: 0.1.2
+    tag: 0.1.6
     pullPolicy: IfNotPresent
   envSecretName: "consumer-dataplane-secret"
   fullnameOverride: "materialpass-edc-dataplane"
@@ -102,7 +102,7 @@ controlplane:
   fullnameOverride: "materialpass-edc-controlplane"
   image:
     repository: ghcr.io/catenax-ng/product-edc/edc-controlplane-postgresql-hashicorp-vault
-    tag: 0.1.2
+    tag: 0.1.6
     pullPolicy: IfNotPresent
   envSecretName: "consumer-controlplane-secret"
   edc:

--- a/deployment/helm/edc-provider/Chart.lock
+++ b/deployment/helm/edc-provider/Chart.lock
@@ -1,29 +1,15 @@
-# Copyright 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
-# 
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-# 
-#     http://www.apache.org/licenses/LICENSE-2.0
-# 
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 dependencies:
 - name: edc-controlplane
   repository: https://catenax-ng.github.io/product-edc
-  version: 0.2.0
+  version: 0.1.6
 - name: edc-dataplane
   repository: https://catenax-ng.github.io/product-edc
-  version: 0.2.0
+  version: 0.1.6
 - name: backend-service
   repository: https://denisneuling.github.io/cx-backend-service
   version: 0.0.6
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 12.1.5
-digest: sha256:a2086d12eedfa4d3d63e8eba9d90b57d2e90b600873684a2588e06381da09db3
-generated: "2023-02-03T12:17:05.5917564+01:00"
+digest: sha256:a3598076f2cd809542558467ea71c9172610100b5c0cd5a21df945adfdb6bc24
+generated: "2023-02-23T10:37:40.9099365+01:00"

--- a/deployment/helm/edc-provider/Chart.yaml
+++ b/deployment/helm/edc-provider/Chart.yaml
@@ -22,12 +22,12 @@ appVersion: "0.4.2"
 dependencies:
   - name: edc-controlplane
     alias: controlplane
-    version: "0.2.0"
+    version: "0.1.6"
     repository: https://catenax-ng.github.io/product-edc
     condition: controlplane.enabled
   - name: edc-dataplane
     alias: dataplane
-    version: "0.2.0"
+    version: "0.1.6"
     repository: https://catenax-ng.github.io/product-edc
     condition: dataplane.enabled
   - name: backend-service

--- a/deployment/helm/edc-provider/values-dev.yaml
+++ b/deployment/helm/edc-provider/values-dev.yaml
@@ -38,7 +38,7 @@ dataplane:
   fullnameOverride: "materialpass-edc-provider-dataplane"
   image:
     repository: ghcr.io/catenax-ng/product-edc/edc-dataplane-hashicorp-vault
-    tag: 0.2.0
+    tag: 0.1.6
     pullPolicy: IfNotPresent
   envSecretName: "provider-dataplane-secret"
   edc:
@@ -90,7 +90,7 @@ controlplane:
   fullnameOverride: "materialpass-edc-provider-controlplane"
   image:
     repository: ghcr.io/catenax-ng/product-edc/edc-controlplane-postgresql-hashicorp-vault
-    tag: 0.2.0
+    tag: 0.1.6
     pullPolicy: IfNotPresent
   edc:
     endpoints:

--- a/deployment/helm/edc-provider/values-int.yaml
+++ b/deployment/helm/edc-provider/values-int.yaml
@@ -38,7 +38,7 @@ dataplane:
   fullnameOverride: "materialpass-edc-provider-dataplane"
   image:
     repository: ghcr.io/catenax-ng/product-edc/edc-dataplane-hashicorp-vault
-    tag: 0.1.2
+    tag: 0.1.6
     pullPolicy: IfNotPresent
   envSecretName: "provider-dataplane-secret"
   edc:
@@ -90,7 +90,7 @@ controlplane:
   fullnameOverride: "materialpass-edc-provider-controlplane"
   image:
     repository: ghcr.io/catenax-ng/product-edc/edc-controlplane-postgresql-hashicorp-vault
-    tag: 0.1.2
+    tag: 0.1.6
     pullPolicy: IfNotPresent
   edc:
     endpoints:


### PR DESCRIPTION
<!--
 Copyright 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->

## What this PR changes/adds

- Fix EDC version issue to 0.1.6 for consumer and provider
- Fix contract offer catalog issue
- Add readme for digital product passport helm chart