### PR TITLE
Dialog component + imp. for i-icons and battery ID

### DIFF
--- a/src/assets/styles/components/general/dialog.scss
+++ b/src/assets/styles/components/general/dialog.scss
@@ -20,20 +20,31 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/** Global configuration variables **/
-@import "config/variables";
+.dialog-container {
+  position: relative;
+  width: 400px;
+  margin: auto;
+  .title-container {
+    display: flex;
+    font-size: 18px;
+    flex-direction: row;
+    align-items: center;
+    height: 68px;
+  }
 
-/** Components style import **/
-@import "components/general/footer";
-@import "components/general/header";
-@import "components/general/search";
-@import "components/general/tooltip";
-@import "components/general/dialog";
-@import "components/passport/documentField";
-@import "components/passport/field";
-@import "components/passport/cards";
-@import "components/landing/searchView";
-@import "components/passport/sections";
-@import "components/passport/passportPage";
-@import "components/general/notFound";
-@import "components/passport/elementChart";
+  .close-btn-container {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+  }
+
+  .v-btn--block {
+    padding: 0 10px 0 20px;
+  }
+}
+
+@media (max-width: 550px) {
+  .dialog-container {
+    width: 350px;
+  }
+}

--- a/src/components/general/Dialog.vue
+++ b/src/components/general/Dialog.vue
@@ -1,0 +1,61 @@
+<!--
+  Catena-X - Product Passport Consumer Frontend
+ 
+  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ 
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+ 
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  either express or implied. See the
+  License for the specific language govern in permissions and limitations
+  under the License.
+ 
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<template>
+  <div>
+    <div @click="dialog = true">
+      <slot></slot>
+    </div>
+    <v-dialog v-model="dialog">
+      <v-card class="dialog-container">
+        <v-card-title class="title-container">
+          <v-icon start size="small" icon="mdi-information-outline"> </v-icon>
+          <slot name="title"> Description </slot>
+          <v-card-actions class="close-btn-container">
+            <v-btn class="close-btn-container" block @click="dialog = false">
+              <v-icon start md icon="mdi-close"></v-icon
+            ></v-btn>
+          </v-card-actions>
+        </v-card-title>
+        <v-divider></v-divider>
+
+        <v-card-text>
+          <slot name="text">
+            <h2>404</h2>
+            <p>No description</p>
+          </slot>
+        </v-card-text>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "DialogComponent",
+  data() {
+    return {
+      dialog: false,
+    };
+  },
+};
+</script>

--- a/src/components/passport/Cards.vue
+++ b/src/components/passport/Cards.vue
@@ -77,11 +77,16 @@
               </div>
             </div>
           </div>
-          <span v-if="card.info" class="card-info-icon">
-            <v-icon start md icon="mdi-information-outline"> </v-icon>
-            <Tooltip>
-              {{ card.info }}
-            </Tooltip>
+          <span v-if="card.description" class="card-info-icon">
+            <DialogComponent>
+              <v-icon start md icon="mdi-information-outline"></v-icon>
+              <template v-slot:title>
+                {{ card.description.title }}
+              </template>
+              <template v-slot:text>
+                {{ card.description.value }}
+              </template>
+            </DialogComponent>
           </span>
         </div>
       </v-col>
@@ -90,15 +95,16 @@
 </template>
 
 <script>
-import Tooltip from "../general/Tooltip.vue";
 import ElementChart from "../passport/ElementChart.vue";
 import BarChart from "../passport/BarChart.vue";
+import DialogComponent from "../general/Dialog.vue";
+
 export default {
   name: "CardsComponent",
   components: {
-    Tooltip,
     ElementChart,
     BarChart,
+    DialogComponent,
   },
   props: {
     data: {
@@ -111,8 +117,7 @@ export default {
       currentValue:
         this.$props.data.passport.batteryCycleLife
           .cycleLifeTestDepthOfDischarge,
-      maxValue:
-        this.$props.data.passport.batteryCycleLife.expectedLifetime,
+      maxValue: this.$props.data.passport.batteryCycleLife.expectedLifetime,
       cards: [
         {
           title: "GENERAL",
@@ -132,16 +137,18 @@ export default {
           secondLabel: "Original Power",
           icon: "mdi-chart-timeline-variant-shimmer",
           value:
-            this.$props.data.passport.electrochemicalProperties
-              .ratedCapacity,
+            this.$props.data.passport.electrochemicalProperties.ratedCapacity,
           valueUnits: "kWh",
           secondValueUnits: "kW",
           secondValue: this.$props.data.passport.electrochemicalProperties
             .batteryPower
-            ? this.$props.data.passport.electrochemicalProperties
-                .batteryPower.originalPowerCapability
+            ? this.$props.data.passport.electrochemicalProperties.batteryPower
+                .originalPowerCapability
             : "-",
-          info: "info",
+          description: {
+            title: "Performance",
+            value: "Description of the performance",
+          },
         },
         {
           title: "HEALTH",
@@ -155,7 +162,10 @@ export default {
           secondValue: this.$props.data.passport.batteryIdentification
             ? this.$props.data.passport.batteryIdentification.batteryModel
             : "-",
-          info: "info",
+          description: {
+            title: "Health",
+            value: "Description of the health",
+          },
         },
         {
           title: "SUSTAINABILITY",
@@ -192,7 +202,10 @@ export default {
             },
           ],
           secondValue: this.$props.data.passport.cO2FootprintTotal,
-          info: "info",
+          description: {
+            title: "Sustainability",
+            value: "Description of the Sustainability",
+          },
         },
       ],
     };

--- a/src/components/passport/sections/GeneralInformation.vue
+++ b/src/components/passport/sections/GeneralInformation.vue
@@ -27,12 +27,20 @@
       <template v-if="propsData.batteryIdentification">
         <v-row>
           <v-col sm="12" md="9" class="pa-0 ma-0">
-            <Field
-              data-cy="battery-id"
-              icon="mdi-fingerprint"
-              label="Battery ID (DMC)"
-              :value="propsData.batteryIdentification.batteryIDDMCCode"
-            />
+            <DialogComponent>
+              <Field
+                data-cy="battery-id"
+                icon="mdi-fingerprint"
+                label="Battery ID (DMC)"
+                :value="propsData.batteryIdentification.batteryIDDMCCode"
+              />
+              <template v-slot:title>
+                {{ descriptions.BatteryId.title }}
+              </template>
+              <template v-slot:text>
+                {{ descriptions.BatteryId.value }}
+              </template>
+            </DialogComponent>
           </v-col>
         </v-row>
       </template>
@@ -168,11 +176,14 @@
 
 <script>
 import Field from "../Field.vue";
+import DialogComponent from "../../general/Dialog.vue";
+import descriptions from "../../../config/templates/descriptions.json";
 
 export default {
   name: "GeneralInformation",
   components: {
     Field,
+    DialogComponent,
   },
   props: {
     sectionTitle: {
@@ -188,6 +199,7 @@ export default {
 
   data() {
     return {
+      descriptions: descriptions,
       toggle: false,
       propsData: this.$props.data.passport,
     };

--- a/src/config/templates/descriptions.json
+++ b/src/config/templates/descriptions.json
@@ -1,0 +1,18 @@
+{
+  "vehicleDismantlingProcedure": {
+    "title": "Vehicle dismantling procedure",
+    "value": "Document containing the vehicle dismantling procedure is describing a regulatory requirement"
+  },
+  "cathodeActiveMaterials": {
+    "title": "Cathode active materials",
+    "value": "The total amount of valuable materials contained in CAM material: Nickel, Cobalt, Lithium"
+  },
+  "MaterialNameAndWeightAndPercentageMassFractionEntity": {
+    "title": "material name and weight and percent",
+    "value": "Entity to bundle a material's name, weight and percentage of mass"
+  },
+  "BatteryId": {
+    "title": "Battery ID",
+    "value": "Battery ID or DMC that you can find in your device settings"
+  }
+}


### PR DESCRIPTION
# Why we create this PR?
 
This PR resolves an issue of lacking descriptions for some of the details of our app.
Things like pop-ups for i-icons or even descriptions for a Field component.
Just for example, Battery ID in the General Information section is implemented.

There is also a new config file --> descriptions.json. It should contain all the descriptions.

NEXT STEPS:
0. Someone should prepare the descriptions and fill out the JSON file.
1. Descriptions should be sent together with the Passport.
2. Dialog component should be added everywhere it's needed
 
# What is new?
 
Dialog component (POP-UP)

## PR Linked to:

https://jira.catena-x.net/browse/CMP-464
