### PR TITLE
Feature/cmp-707/update-license-info-into-markdown-files: added creati…

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,3 +18,9 @@
 | :---:   |
 | [cmp-xxx](www.link.com) |
 | [cmp-xxx](www.link.com)  |
+
+## License
+* SPDX-License-Identifier: CC-BY-4.0
+* Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
+* Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+* Source URL: https://github.com/catenax-ng/tx-digital-product-pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -311,3 +311,9 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 - Optimized the reponsive from the application
 - Optimized the passport display
 - Updated components with Vuetify 3, making the application more stable. 
+
+## License
+* SPDX-License-Identifier: CC-BY-4.0
+* Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
+* Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+* Source URL: https://github.com/catenax-ng/tx-digital-product-pass

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -66,3 +66,9 @@ Project committers or leaders who do not follow the Code of Conduct in good fait
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org) , version 1.4, available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html](https://www.contributor-covenant.org/version/1/4/code-of-conduct/)
+
+## License
+* SPDX-License-Identifier: CC-BY-4.0
+* Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
+* Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+* Source URL: https://github.com/catenax-ng/tx-digital-product-pass

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,3 +79,9 @@ https://www.eclipse.org/projects/handbook/#resources-commit
 Contact the project developers via the project's "dev" list.
 
 * https://accounts.eclipse.org/mailing-list/tractusx-dev
+
+## License
+* SPDX-License-Identifier: CC-BY-4.0
+* Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
+* Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+* Source URL: https://github.com/catenax-ng/tx-digital-product-pass

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -68,3 +68,9 @@ another country, of encryption software. BEFORE using any encryption software,
 please check the country's laws, regulations and policies concerning the import,
 possession, or use, and re-export of encryption software, to see if this is
 permitted.
+
+## License
+* SPDX-License-Identifier: CC-BY-4.0
+* Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
+* Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+* Source URL: https://github.com/catenax-ng/tx-digital-product-pass

--- a/README.md
+++ b/README.md
@@ -129,4 +129,8 @@ See [VSCode configuration](https://code.visualstudio.com/docs/getstarted/setting
 
 ## License
 
-[Apache-2.0](https://raw.githubusercontent.com/eclipse-tractusx/digital-product-pass/digital-product-pass/main/LICENSE)
+* [Apache-2.0](https://raw.githubusercontent.com/eclipse-tractusx/digital-product-pass/digital-product-pass/main/LICENSE)
+* SPDX-License-Identifier: CC-BY-4.0
+* Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
+* Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+* Source URL: https://github.com/catenax-ng/tx-digital-product-pass

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,3 +26,9 @@
 
 Please report a found vulnerability here:
 [https://www.eclipse.org/security/](https://www.eclipse.org/security/)
+
+## License
+* SPDX-License-Identifier: CC-BY-4.0
+* Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
+* Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+* Source URL: https://github.com/catenax-ng/tx-digital-product-pass

--- a/charts/digital-product-pass/README.md
+++ b/charts/digital-product-pass/README.md
@@ -14,3 +14,9 @@ helm install digital-product-pass . -f ./values.yaml -f ./values.dev.yaml
 ## Source Code
 
 * [charts/digital-product-pass](.)
+
+## License
+* SPDX-License-Identifier: CC-BY-4.0
+* Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
+* Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+* Source URL: https://github.com/catenax-ng/tx-digital-product-pass

--- a/consumer-backend/productpass/readme.md
+++ b/consumer-backend/productpass/readme.md
@@ -294,5 +294,9 @@ mvn clean spring-boot:run
 
 
 # License
-[Apache-2.0](https://raw.githubusercontent.com/catenax-ng/product-battery-passport-consumer-app/main/LICENSE)
+* [Apache-2.0](https://raw.githubusercontent.com/catenax-ng/product-battery-passport-consumer-app/main/LICENSE)
+* SPDX-License-Identifier: CC-BY-4.0
+* Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
+* Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+* Source URL: https://github.com/catenax-ng/tx-digital-product-pass
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -173,3 +173,10 @@ helm pull --untar [rep/chartname] # untar the chart after downloading it
 
 </p>
 </details>
+
+
+## License
+* SPDX-License-Identifier: CC-BY-4.0
+* Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
+* Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+* Source URL: https://github.com/catenax-ng/tx-digital-product-pass

--- a/docker/README.md
+++ b/docker/README.md
@@ -58,3 +58,9 @@ Add this parameter when running docker run:
 ```bash
 -e "JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000" -p 8000:8000
 ```
+
+## License
+* SPDX-License-Identifier: CC-BY-4.0
+* Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
+* Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+* Source URL: https://github.com/catenax-ng/tx-digital-product-pass

--- a/docker/local/Keycloak/README.md
+++ b/docker/local/Keycloak/README.md
@@ -63,3 +63,9 @@ The keycloak configurations are defined in [src/services/service.const.js](../..
 npm install --legacy-peer-deps
 npm run serve
 ```
+
+## License
+* SPDX-License-Identifier: CC-BY-4.0
+* Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
+* Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+* Source URL: https://github.com/catenax-ng/tx-digital-product-pass

--- a/docs/admin guide/Admin_Guide.md
+++ b/docs/admin guide/Admin_Guide.md
@@ -367,3 +367,9 @@ Once you finish the configuration, to make the endpoint public configure in the 
 *The BPN number is not required for the configuration of the endpoint, just **make sure that the host is pointing to the EDC Provider**.*
 
 
+## License
+* SPDX-License-Identifier: CC-BY-4.0
+* Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
+* Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+* Source URL: https://github.com/catenax-ng/tx-digital-product-pass
+

--- a/docs/arc42/Arc42.md
+++ b/docs/arc42/Arc42.md
@@ -465,3 +465,9 @@ An user needs to be able to understand easily the application interface, in orde
 | Git | Is a distributed version control system: tracking changes in any set of files, usually used for coordinating work among programmers collaboratively developing source code during software development. |
 | DevOps | Is a set of practices that combines software development (Dev) and IT operations (Ops). It aims to shorten the systems development life cycle and provide continuous delivery with high software quality. |
 | Repository | Is a database of digital content with an associated set of data management, search and access methods allowing application-independent access to the content, rather like a digital library, but with the ability to store and modify content in addition to searching and retrieving. |
+
+## License
+* SPDX-License-Identifier: CC-BY-4.0
+* Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
+* Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+* Source URL: https://github.com/catenax-ng/tx-digital-product-pass

--- a/docs/business statement/Business Statement.md
+++ b/docs/business statement/Business Statement.md
@@ -80,3 +80,9 @@ The following candidates are not yet implemented:
 * Gearbox Passport
 * Sealant Passport, Tire Passport
 * Generic Product Passport
+
+## License
+* SPDX-License-Identifier: CC-BY-4.0
+* Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
+* Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+* Source URL: https://github.com/catenax-ng/tx-digital-product-pass

--- a/docs/cypress/CYPRESS.md
+++ b/docs/cypress/CYPRESS.md
@@ -47,3 +47,9 @@ This is the documentation for Battery Passport App E2E Cypress test.
 
 ![test](./test2.png)  
 </br></br>
+
+## License
+* SPDX-License-Identifier: CC-BY-4.0
+* Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
+* Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+* Source URL: https://github.com/catenax-ng/tx-digital-product-pass

--- a/docs/user manual/User Manual Product Viewer App.md
+++ b/docs/user manual/User Manual Product Viewer App.md
@@ -69,3 +69,9 @@ Hereby, the information is devided into the following sections:
 7. Data exchange Information
 
 Each category can be accessed by clicking on its heading in the selection bar towards the middle of the product passport screen (7).
+
+## License
+* SPDX-License-Identifier: CC-BY-4.0
+* Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
+* Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+* Source URL: https://github.com/catenax-ng/tx-digital-product-pass

--- a/postman/README.md
+++ b/postman/README.md
@@ -39,3 +39,9 @@ This technical guide depicts the battery pass end-to-end API calls through the p
 - Configure the ***clientId*** and ***clientSecret*** environment variables from the variables tab inside root directory.
 
 For more technical documentation, please refer to the [catenax-at-home-getting-started-guide](https://catenax-ng.github.io/docs/guides/catenax-at-home)
+
+## License
+* SPDX-License-Identifier: CC-BY-4.0
+* Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
+* Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+* Source URL: https://github.com/catenax-ng/tx-digital-product-pass


### PR DESCRIPTION
…ve commons atribution 4.0 international license info into all markup files

# Why we create this PR?
 
There is a requirement to reference the Creative Commons Attribution 4.0 International license information in all Markdown files [TRG 7.07](https://github.com/eclipse-tractusx/digital-product-pass/issues/60).
# What we want to achieve with this PR?
 
Add a License heading in every markdown file with the following information:
* SPDX-License-Identifier: CC-BY-4.0
* Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
* Copyright statements
* Source URL: (URL to the Repository)
 
# What is new?

## Updated
 
        modified:   .github/PULL_REQUEST_TEMPLATE.md
        modified:   README.md
        modified:   CHANGELOG.md
        modified:   CODE_OF_CONDUCT.md
        modified:   CONTRIBUTING.md
        modified:   NOTICE.md
        modified:   SECURITY.md
        modified:   charts/digital-product-pass/README.md
        modified:   consumer-backend/productpass/readme.md
        modified:   deployment/README.md
        modified:   docker/README.md
        modified:   docker/local/Keycloak/README.md
        modified:   docs/admin guide/Admin_Guide.md
        modified:   docs/arc42/Arc42.md
        modified:   docs/business statement/Business Statement.md
        modified:   docs/cypress/CYPRESS.md
        modified:   docs/user manual/User Manual Product Viewer App.md
        modified:   postman/README.md


## PR Linked to:

| Tickets |
| :---:   |
| [cmp-707](https://jira.catena-x.net/browse/CMP-707) |