### PR TITLE
feature/cmp-706/add-legal-files-into-jar: updated pom.xml file to cop…

### DIFF
--- a/consumer-backend/productpass/pom.xml
+++ b/consumer-backend/productpass/pom.xml
@@ -179,6 +179,17 @@
         </dependency>
     </dependencies>
 	<build>
+         <resources>
+            <resource>
+                <directory>${project.basedir}/../..</directory>
+                <includes>
+                    <include>LICENSE</include>
+                    <include>NOTICE.md</include>
+                    <include>DEPENDENCIES_BACKEND</include>
+                </includes>
+                <targetPath>META-INF\maven\org.eclipse.tractusx\productpass\</targetPath>
+            </resource>
+        </resources>
 		<plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
…y the needed files into META-INF folder inside jar file

# Why we create this PR?
 
There is a requirement to add License, notice and DEPENDENCIES_BACKEND files into the JAR file [TRG 7.05](https://github.com/eclipse-tractusx/digital-product-pass/issues/70).
 
# What we want to achieve with this PR?
 
In every distribution artifact the mentioned files must be within the compiled JAR file, inside the META-INF folder. 
 
# What is new?
 
### Updated
`modified:   consumer-backend/productpass/pom.xml`

The files were pasted in JAR file inside \META-INF\maven\org.eclipse.tractusx\productpass\ folder as shown:
![image](https://github.com/catenax-ng/tx-digital-product-pass/assets/136568749/7f53b688-d738-4180-a7f1-073d76da770c)

## PR Linked to:

| Tickets |
| :---:   |
| [cmp-706](https://jira.catena-x.net/browse/CMP-706) |