### PR TITLE
feature/cmp-704/add-resource-utilization: add default CPU and memory settings in helm

### DIFF
--- a/charts/digital-product-pass/values.yaml
+++ b/charts/digital-product-pass/values.yaml
@@ -47,7 +47,6 @@ frontend:
         paths:
           - path: /passport(/|$)(.*)
             pathType: Prefix
-
   avp:
     helm:
       clientId: "Add your secret here"
@@ -166,18 +165,15 @@ backend:
           max-connections: 10000
 
 
-
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+# Following Catena-X Helm Best Practices @url: https://catenax-ng.github.io/docs/kubernetes-basics/helm
+# @url: https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-resource-requests-and-limits
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 250m
+    memory: 512Mi
 
 nodeSelector: {}
 


### PR DESCRIPTION
# Why we create this PR?
 
As best practices and to comply with the [TRG-5.04](https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-04/) requirement, add default CPU and memory settings for the digital product pass deployment.
 
# What we want to achieve with this PR?
 
To track the resource utilization of the product.
 
# What is new?
 
## Added
- Added resource management settings to better utilize CPU and memory consumption in DPP helm deployment.

| Tickets |
| :---:   |
| [cmp-704](https://jira.catena-x.net/browse/CMP-704) |