### PR TITLE
feat: added the base images used in the project in the main README.md…

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ To get started you can have a look into our documentation:
 | [Postman Overview](./postman/README.md)                                    | Technical guide depicts the battery pass end-to-end API calls through the postman REST client                                                                      |
 | [Changelog](./CHANGELOG.md)                                                | Changelog                                                                                                                                                          |
 
+## Base Images
+| Language | Container Base Image |
+| :------- | :------------------- |
+| Java / JVM based   | [Eclipse Temurin](https://hub.docker.com/_/eclipse-temurin) |
+| JS frontends       | [Node.JS](https://hub.docker.com/_/node)  <br/> [Nginx](https://hub.docker.com/r/nginxinc/nginx-unprivileged) |
+      
+
 ### Prerequisites:
 
 - Git


### PR DESCRIPTION
… file

# Why we create this PR?
 
This is a requirement to add the base images used in the project [TRG 4.02](https://github.com/eclipse-tractusx/digital-product-pass/issues/82)
 
# What we want to achieve with this PR?
 
Add the base images used in the project into the main README.md file.
 
# What is new?
 
Created a new subtitle in README.md file with Base images information:
![image](https://github.com/catenax-ng/tx-digital-product-pass/assets/136568749/7ebc2636-17ca-456e-bdca-b43962ae1f30)


## PR Linked to:

| Tickets |
| :---:   |
| [cmp-710](https://jira.catena-x.net/browse/CMP-710) |