### PR TITLE
feature/cmp-709/add-user-security: add user and file permissions in dockerfile and helm deployment

### DIFF
--- a/.github/workflows/publish-dpp-frontend-docker-image.yml
+++ b/.github/workflows/publish-dpp-frontend-docker-image.yml
@@ -29,7 +29,7 @@ name: "Publish Digital Product Pass Frontend Docker Images"
 
 on:
   push:
-    branches: [ "main", "develop" ]
+    branches: [ "main", "develop", "feature/cmp-709/add-user-security" ]
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:

--- a/.github/workflows/publish-dpp-frontend-docker-image.yml
+++ b/.github/workflows/publish-dpp-frontend-docker-image.yml
@@ -29,7 +29,7 @@ name: "Publish Digital Product Pass Frontend Docker Images"
 
 on:
   push:
-    branches: [ "main", "develop", "feature/cmp-709/add-user-security" ]
+    branches: [ "main", "develop" ]
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ WORKDIR /app
 # Copy the package.json and install dependencies
 COPY package*.json ./
 
+RUN npm install -g npm
+
 #RUN npm install
 RUN npm install --legacy-peer-deps
 
@@ -45,25 +47,30 @@ ARG REPO_ENDPOINT_URL='REPO_ENDPOINT_URL'
 ENV REPO_COMMIT_ID=${REPO_COMMIT_ID}
 ENV REPO_ENDPOINT_URL=${REPO_ENDPOINT_URL}
 
-COPY ./entrypoint.sh /entrypoint.sh
+USER root
 
-HEALTHCHECK NONE
+RUN addgroup -g 3000 appgroup \
+	&& adduser -u 10000 -g 3000 -h /home/appuser -D appuser
+
+COPY ./entrypoint.sh /entrypoint.sh
 
 WORKDIR /app
 
 COPY ./.nginx/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-USER root
+HEALTHCHECK NONE
 
-RUN chmod +x /entrypoint.sh
-
+# add permissions for a user
+RUN chown -R 10000:3000 /app && chmod -R 775 /app/
+RUN chown 10000:3000 /entrypoint.sh && chmod -R 775 /entrypoint.sh
 
 # Install bash for env variables inject script
 RUN apk update && apk add --no-cache bash
 # Make nginx owner of /usr/share/nginx/html/ and change to nginx user
-RUN chown -R 1001:1001 /usr/share/nginx/html/
-USER 1001
+RUN chown -R 10000:3000 /usr/share/nginx/html/
+
+USER 10000:3000
 
 EXPOSE 8080
 

--- a/charts/digital-product-pass/templates/deployment-frontend.yaml
+++ b/charts/digital-product-pass/templates/deployment-frontend.yaml
@@ -41,12 +41,17 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      securityContext:
+        runAsUser: 10000
+        fsGroup: 3000
       containers:
         - name: {{ .Values.frontend.name }}
           image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
           securityContext: 
-            allowPrivilegeEscalation: false 
+            allowPrivilegeEscalation: false
+            runAsUser: 10000
+            runAsGroup: 3000
           env:          
             - name: "VUE_APP_CLIENT_ID"
               valueFrom:


### PR DESCRIPTION
# Why we create this PR?
 
Added user and file permissions in Dockerfile and container configurations to be able to run as a non-root user to ensure application security.

# What we want to achieve with this PR?
 
To meet [TRG 4.03](https://eclipse-tractusx.github.io/docs/release/trg-4/trg-4-03/) according to Tractus-x standards.
 
# What is new?
 
## Added
- Added user and file permissions to run as a non root user to secure the DPP application.

| Tickets |
| :---:   |
| [cmp-709](https://jira.catena-x.net/browse/CMP-709) |