### PR TITLE
bugfix/fix-pvc-data: update data persistent to data directory 

### DIFF
--- a/charts/digital-product-pass/templates/deployment-backend.yaml
+++ b/charts/digital-product-pass/templates/deployment-backend.yaml
@@ -77,8 +77,8 @@ spec:
             - name: backend-config
               mountPath: /app/config
             - name: pvc-backend
-              mountPath: /app/data/process
-              subPath: process
+              mountPath: /app/data
+              subPath: data
             - name: pvc-backend
               mountPath: /app/log
               subPath: log


### PR DESCRIPTION
# Why we create this PR?
 
Fix `mountPath` and `subPath` to the entire data directory to be persisted using persistent volume in backend deployment.
 
# What we want to achieve with this PR?
 
To store contract details as well as EDC and BPN endpoint details.
 
# What is new?
 
## Updated
- Update persistence layer to store contract as well as EDC and BPN endpoint details.

## PR Linked to:

[#118](https://github.com/catenax-ng/tx-digital-product-pass/pull/118)

| Tickets |
| :---:   |
| [cmp-604](https://jira.catena-x.net/browse/CMP-604) |