### PR TITLE
feature/cmp-701/add-helm-upgrade-workflow: prepare helm upgrade to achieve pre-release upgradeability

### DIFF
--- a/.github/workflows/helm-upgrade.yaml
+++ b/.github/workflows/helm-upgrade.yaml
@@ -58,10 +58,10 @@ jobs:
       - name: Run helm install
         # Install latest released digital-product-pass version
         run: |
-          helm install dpp tractusx-dev/digital-product-pass
+          helm install dpp tractusx-dev/digital-product-pass -n product-material-pass --create-namespace
 
       - name: Run helm upgrade
         # Upgrade the installed dpp version with the locally available charts
         run: |
           helm dependency update charts/digital-product-pass
-          helm upgrade dpp charts/digital-product-pass
+          helm upgrade dpp charts/digital-product-pass -n product-material-pass

--- a/.github/workflows/helm-upgrade.yaml
+++ b/.github/workflows/helm-upgrade.yaml
@@ -1,0 +1,67 @@
+#################################################################################
+# Catena-X - Product Passport Consumer Application
+#
+# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+name: Upgrade Charts
+
+on:
+  push:
+    branches: [ "main", "develop", "feature/cmp-701/add-helm-upgrade-workflow" ]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to use"
+        required: true
+        default: 'main'
+        type: string
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Kubernetes KinD Cluster
+        uses: container-tools/kind-action@v2
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.9.3
+
+      - name: Add repos
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
+          
+      - name: Run helm install
+        # Install latest released digital-product-pass version
+        run: |
+          helm install dpp tractusx-dev/digital-product-pass
+
+      - name: Run helm upgrade
+        # Upgrade the installed dpp version with the locally available charts
+        run: |
+          helm dependency update charts/digital-product-pass
+          helm upgrade dpp charts/digital-product-pass

--- a/.github/workflows/helm-upgrade.yaml
+++ b/.github/workflows/helm-upgrade.yaml
@@ -23,8 +23,9 @@
 name: Upgrade Charts
 
 on:
-  push:
-    branches: [ "main", "develop", "feature/cmp-701/add-helm-upgrade-workflow" ]
+  pull_request:
+    paths:
+      - 'charts/digital-product-pass/**'
   workflow_dispatch:
     inputs:
       branch:
@@ -34,8 +35,9 @@ on:
         type: string
 
 jobs:
-  lint-test:
+  upgrade:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'eclipse-tractusx/digital-product-pass' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
# Why we create this PR?
 
Prepared [helm upgrade](https://github.com/catenax-ng/tx-digital-product-pass/blob/feature/cmp-701/add-helm-upgrade-workflow/.github/workflows/helm-upgrade.yaml) git workflow to ensure pre-release upgradeability of the helm deployment according to [TRG-5.11](https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-11/) standards.

# What we want to achieve with this PR?
 
To meet the [TRG-5.11](https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-11/) requirement.

# What is new?
 
## Added
- Added helm upgrade workflow to achieve pre-release upgradeability of the helm charts.

| Tickets |
| :---:   |
| [cmp-701](https://jira.catena-x.net/browse/CMP-701) |