### PR TITLE
feature/cmp 700/Kubernetes versions testing: Support helm charts on different kubernetes versions

### DIFF
--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -35,7 +35,7 @@ on:
       node_image:
         description: 'kindest/node image for k8s kind cluster'
         # k8s version from 3.1 release as default
-        default: 'kindest/node:v1.24.6'
+        default: 'kindest/node:v1.27.3'
         required: false
         type: string
       upgrade_from:
@@ -63,7 +63,7 @@ jobs:
           # upgrade version, default (v0.17.0) uses node image v1.21.1 and doesn't work with more recent node image versions
           version: v0.19.0
           # default value for event_name != workflow_dispatch
-          node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.24.6' }}
+          node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.27.3' }}
 
       - name: Build image for frontend
         id: build-frontend

--- a/charts/digital-product-pass/values-beta.yaml
+++ b/charts/digital-product-pass/values-beta.yaml
@@ -25,7 +25,7 @@ frontend:
     enabled: true
     #className: ""
     annotations:
-      kubernetes.io/ingress.class: nginx
+      ingressClassName: nginx
       # kubernetes.io/tls-acme: "true"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
       nginx.ingress.kubernetes.io/ssl-passthrough: "false"
@@ -58,8 +58,7 @@ backend:
     enabled: true
     # className: "nginx"
     annotations:
-      kubernetes.io/ingress.class: nginx
-      #kubernetes.io/ingress.class: nginx
+      ingressClassName: nginx
       # kubernetes.io/tls-acme: "true"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
       nginx.ingress.kubernetes.io/ssl-passthrough: "false"

--- a/charts/digital-product-pass/values-dev.yaml
+++ b/charts/digital-product-pass/values-dev.yaml
@@ -25,7 +25,7 @@ frontend:
     enabled: true
     #className: ""
     annotations:
-      kubernetes.io/ingress.class: nginx
+      ingressClassName: nginx
       # kubernetes.io/tls-acme: "true"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
       nginx.ingress.kubernetes.io/ssl-passthrough: "false"
@@ -58,8 +58,7 @@ backend:
     enabled: true
     # className: "nginx"
     annotations:
-      kubernetes.io/ingress.class: nginx
-      #kubernetes.io/ingress.class: nginx
+      ingressClassName: nginx
       # kubernetes.io/tls-acme: "true"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
       nginx.ingress.kubernetes.io/ssl-passthrough: "false"

--- a/charts/digital-product-pass/values-int.yaml
+++ b/charts/digital-product-pass/values-int.yaml
@@ -25,7 +25,7 @@ frontend:
     enabled: true
     #className: ""
     annotations:
-      kubernetes.io/ingress.class: nginx
+      ingressClassName: nginx
       # kubernetes.io/tls-acme: "true"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
       nginx.ingress.kubernetes.io/ssl-passthrough: "false"
@@ -58,8 +58,7 @@ backend:
     enabled: true
     # className: "nginx"
     annotations:
-      kubernetes.io/ingress.class: nginx
-      #kubernetes.io/ingress.class: nginx
+      ingressClassName: nginx
       # kubernetes.io/tls-acme: "true"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
       nginx.ingress.kubernetes.io/ssl-passthrough: "false"


### PR DESCRIPTION
# Why we create this PR?
 
New Kubernetes versions are [released](https://kubernetes.io/releases/) every few months. The compatibility with those versions needs to be verified as [APIs](https://kubernetes.io/docs/concepts/overview/kubernetes-api/) get deprecated. New Versions can also introduce issues.

To make Eclipse Tractus-X usable in the industry, its necessary to support and test multiple Kubernetes versions (upcoming, stable, old). API deprecations are happening slowly but regularly.

The helm deployment is tested and adjusted for the following Kubernetes versions:
- v1.27.3
- v1.26.6
- v1.25.11
- v1.24.15

The GitHub action [helm-test.yaml](https://github.com/catenax-ng/tx-digital-product-pass/blob/develop/.github/workflows/helm-test.yaml) is modified with the new [kind](https://kind.sigs.k8s.io/) version for Kubernetes.

# What we want to achieve with this PR?

To achieve the [TRG-5.10 - Kubernetes versions pre-release](https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-10/) requirement.

Updated a GitHub action [helm-test.yaml](https://github.com/catenax-ng/tx-digital-product-pass/blob/develop/.github/workflows/helm-test.yaml) which runs helm test against all required kubernetes versions.

The GitHub Action either can be triggered manually and allows for selecting the kubernetes versions or it verifies all required kubernetes versions one after the other.

# What is new?
 
## Added
- Added new kind cluster version to support different kubernetes versions for helm tests

## Updated
- Updated ingress annotation to support various Kubernetes versions in helm values 

| Tickets |
| :---:   |
| [cmp-700](https://jira.catena-x.net/browse/CMP-700) |