### PR TITLE
feature/cmp 740/edc 5.x: Upgraded EDC and Backend to support the new v0.5.0 version

### DIFF
--- a/DEPENDENCIES_BACKEND
+++ b/DEPENDENCIES_BACKEND
@@ -25,6 +25,7 @@ maven/mavencentral/commons-beanutils/commons-beanutils/1.9.4, Apache-2.0, approv
 maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, CQ10385
 maven/mavencentral/commons-lang/commons-lang/2.6, Apache-2.0, approved, CQ6183
 maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
+maven/mavencentral/commons-net/commons-net/3.9.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.github.classgraph/classgraph/4.8.149, MIT, approved, CQ22530
 maven/mavencentral/io.micrometer/micrometer-commons/1.11.0, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9243
 maven/mavencentral/io.micrometer/micrometer-observation/1.11.0, Apache-2.0, approved, #9242
@@ -84,18 +85,18 @@ maven/mavencentral/org.sonatype.plexus/plexus-sec-dispatcher/1.4, Apache-2.0, ap
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-common/2.0.2, Apache-2.0, approved, #5920
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-api/2.0.2, Apache-2.0, approved, #5950
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-ui/2.0.2, Apache-2.0, approved, #5923
-maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.1.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.1.0, Apache-2.0, approved, #9341
 maven/mavencentral/org.springframework.boot/spring-boot-starter-data-rest/3.1.0, Apache-2.0, approved, #9105
-maven/mavencentral/org.springframework.boot/spring-boot-starter-json/3.1.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/3.1.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-starter-json/3.1.0, Apache-2.0, approved, #9336
+maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/3.1.0, Apache-2.0, approved, #9343
 maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-client/3.1.0, Apache-2.0, approved, #8806
 maven/mavencentral/org.springframework.boot/spring-boot-starter-reactor-netty/3.1.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework.boot/spring-boot-starter-security/3.0.2, Apache-2.0, approved, #7329
-maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat/3.1.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat/3.1.0, Apache-2.0, approved, #9351
 maven/mavencentral/org.springframework.boot/spring-boot-starter-web/3.0.2, Apache-2.0, approved, #5945
 maven/mavencentral/org.springframework.boot/spring-boot-starter-webflux/3.1.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.springframework.boot/spring-boot-starter/3.1.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.springframework.boot/spring-boot/3.1.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-starter/3.1.0, Apache-2.0, approved, #9349
+maven/mavencentral/org.springframework.boot/spring-boot/3.1.0, Apache-2.0, approved, #9352
 maven/mavencentral/org.springframework.cloud/spring-cloud-commons/3.1.5, Apache-2.0, approved, #4726
 maven/mavencentral/org.springframework.cloud/spring-cloud-context/3.1.5, Apache-2.0, approved, #4722
 maven/mavencentral/org.springframework.cloud/spring-cloud-starter-bootstrap/3.1.5, Apache-2.0, approved, clearlydefined
@@ -110,7 +111,7 @@ maven/mavencentral/org.springframework.security/spring-security-core/6.1.0, Apac
 maven/mavencentral/org.springframework.security/spring-security-crypto/6.1.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework.security/spring-security-oauth2-client/6.1.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework.security/spring-security-oauth2-core/6.1.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.springframework.security/spring-security-oauth2-jose/6.1.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.security/spring-security-oauth2-jose/6.1.0, Apache-2.0, approved, #9345
 maven/mavencentral/org.springframework.security/spring-security-rsa/1.0.11.RELEASE, Apache-2.0, approved, CQ20647
 maven/mavencentral/org.springframework.security/spring-security-web/6.1.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework.session/spring-session-core/3.1.0, Apache-2.0, approved, clearlydefined

--- a/consumer-backend/productpass/pom.xml
+++ b/consumer-backend/productpass/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.eclipse.tractusx</groupId>
     <artifactId>productpass</artifactId>
-    <version>1.0.0-alpha-SNAPSHOT</version>
+    <version>1.0.0</version>
     <packaging>jar</packaging>
     <name>Catena-X Digital Product Passport Backend</name>
     <description>Product Passport Consumer Backend System for Product Passport Consumer Frontend Application
@@ -167,6 +167,11 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.10</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
+            <version>3.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/http/controllers/AppController.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/http/controllers/AppController.java
@@ -34,6 +34,7 @@ import org.eclipse.tractusx.productpass.config.ProcessConfig;
 import org.eclipse.tractusx.productpass.exceptions.ControllerException;
 import org.eclipse.tractusx.productpass.managers.ProcessManager;
 import org.eclipse.tractusx.productpass.models.edc.DataPlaneEndpoint;
+import org.eclipse.tractusx.productpass.models.edc.Jwt;
 import org.eclipse.tractusx.productpass.models.http.Response;
 import org.eclipse.tractusx.productpass.models.passports.Passport;
 import org.eclipse.tractusx.productpass.services.DataPlaneService;
@@ -94,7 +95,6 @@ public class AppController {
     }
 
     public  DataPlaneEndpoint getEndpointData(Object body) throws ControllerException {
-        LogUtil.printMessage(this.jsonUtil.toJson(body, true));
         DataPlaneEndpoint endpointData = edcUtil.parseDataPlaneEndpoint(body);
         if(endpointData == null){
             throw new ControllerException(this.getClass().getName(),"The endpoint data request is empty!");
@@ -105,7 +105,8 @@ public class AppController {
         if(endpointData.getAuthCode().isEmpty()){
             throw new ControllerException(this.getClass().getName(),"The authorization code is empty!");
         }
-        if(endpointData.getOfferId().isEmpty()){
+        Jwt token = httpUtil.parseToken(endpointData.getAuthCode());
+        if(!token.getPayload().containsKey("cid") || token.getPayload().get("cid").equals("")){
             throw new ControllerException(this.getClass().getName(),"The Offer Id is empty!");
         }
         return endpointData;

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/http/controllers/AppController.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/http/controllers/AppController.java
@@ -105,7 +105,7 @@ public class AppController {
         if(endpointData.getAuthCode().isEmpty()){
             throw new ControllerException(this.getClass().getName(),"The authorization code is empty!");
         }
-        if(endpointData.getProperties() == null){
+        if(!endpointData.offerIdExists()){
             Jwt token = httpUtil.parseToken(endpointData.getAuthCode());
             if(!token.getPayload().containsKey("cid") || token.getPayload().get("cid").equals("")){
                 throw new ControllerException(this.getClass().getName(),"The Offer Id is empty!");

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/http/controllers/AppController.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/http/controllers/AppController.java
@@ -105,10 +105,17 @@ public class AppController {
         if(endpointData.getAuthCode().isEmpty()){
             throw new ControllerException(this.getClass().getName(),"The authorization code is empty!");
         }
-        Jwt token = httpUtil.parseToken(endpointData.getAuthCode());
-        if(!token.getPayload().containsKey("cid") || token.getPayload().get("cid").equals("")){
-            throw new ControllerException(this.getClass().getName(),"The Offer Id is empty!");
+        if(endpointData.getProperties() == null){
+            Jwt token = httpUtil.parseToken(endpointData.getAuthCode());
+            if(!token.getPayload().containsKey("cid") || token.getPayload().get("cid").equals("")){
+                throw new ControllerException(this.getClass().getName(),"The Offer Id is empty!");
+            }
+        }else{
+            if(endpointData.getOfferId().isEmpty()){
+                throw new ControllerException(this.getClass().getName(),"The authorization code is empty!");
+            }
         }
+
         return endpointData;
     }
 
@@ -124,8 +131,6 @@ public class AppController {
             if(endpointData == null){
                 return httpUtil.buildResponse(httpUtil.getBadRequest("Failed to get data plane endpoint data"), httpResponse);
             }
-
-
 
             if(!processManager.checkProcess(processId)){
                 return httpUtil.buildResponse(httpUtil.getNotFound("Process not found!"), httpResponse);

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/http/controllers/AppController.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/http/controllers/AppController.java
@@ -29,6 +29,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.apache.juli.logging.Log;
 import org.eclipse.tractusx.productpass.config.ProcessConfig;
 import org.eclipse.tractusx.productpass.exceptions.ControllerException;
 import org.eclipse.tractusx.productpass.managers.ProcessManager;
@@ -36,6 +37,7 @@ import org.eclipse.tractusx.productpass.models.edc.DataPlaneEndpoint;
 import org.eclipse.tractusx.productpass.models.http.Response;
 import org.eclipse.tractusx.productpass.models.passports.Passport;
 import org.eclipse.tractusx.productpass.services.DataPlaneService;
+import org.sonarsource.scanner.api.internal.shaded.minimaljson.Json;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.web.bind.annotation.*;
@@ -58,7 +60,8 @@ public class AppController {
 
     @Autowired
     Environment env;
-
+    @Autowired
+    JsonUtil jsonUtil;
     @Autowired
     PassportUtil passportUtil;
 
@@ -91,6 +94,7 @@ public class AppController {
     }
 
     public  DataPlaneEndpoint getEndpointData(Object body) throws ControllerException {
+        LogUtil.printMessage(this.jsonUtil.toJson(body, true));
         DataPlaneEndpoint endpointData = edcUtil.parseDataPlaneEndpoint(body);
         if(endpointData == null){
             throw new ControllerException(this.getClass().getName(),"The endpoint data request is empty!");
@@ -119,6 +123,8 @@ public class AppController {
             if(endpointData == null){
                 return httpUtil.buildResponse(httpUtil.getBadRequest("Failed to get data plane endpoint data"), httpResponse);
             }
+
+
 
             if(!processManager.checkProcess(processId)){
                 return httpUtil.buildResponse(httpUtil.getNotFound("Process not found!"), httpResponse);

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/managers/ProcessManager.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/managers/ProcessManager.java
@@ -425,7 +425,7 @@ public class ProcessManager {
     }
     public String getContractId(DataPlaneEndpoint endpointData){
 
-        if(endpointData.getProperties() == null) {
+        if(!endpointData.offerIdExists()) {
             Jwt token = httpUtil.parseToken(endpointData.getAuthCode());
             return (String) token.getPayload().get("cid");
         }

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/models/edc/DataPlaneEndpoint.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/models/edc/DataPlaneEndpoint.java
@@ -40,11 +40,15 @@ public class DataPlaneEndpoint {
     @JsonProperty("authCode")
     String authCode;
 
-    public DataPlaneEndpoint(String id, String endpoint, String authKey, String authCode) {
+    @JsonProperty("properties")
+    Properties properties;
+
+    public DataPlaneEndpoint(String id, String endpoint, String authKey, String authCode, Properties properties) {
         this.id = id;
         this.endpoint = endpoint;
         this.authKey = authKey;
         this.authCode = authCode;
+        this.properties = properties;
     }
 
     public DataPlaneEndpoint() {
@@ -81,4 +85,28 @@ public class DataPlaneEndpoint {
     public void setAuthCode(String authCode) {
         this.authCode = authCode;
     }
+
+    public Properties getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Properties properties) {
+        this.properties = properties;
+    }
+
+    public void setOfferId(String offerId) {
+        this.properties.offerId = offerId;
+    }
+
+    public String getOfferId() {
+        return this.properties.offerId;
+    }
+
+    static class Properties {
+        @JsonProperty("https://w3id.org/edc/v0.0.1/ns/cid")
+        String offerId;
+
+    }
+
+
 }

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/models/edc/DataPlaneEndpoint.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/models/edc/DataPlaneEndpoint.java
@@ -104,6 +104,15 @@ public class DataPlaneEndpoint {
         return this.properties.offerId;
     }
 
+    public Boolean offerIdExists(){
+        try {
+            return this.properties != null && this.properties.offerId != null;
+        }catch (Exception e){
+            // Do nothing because is non-existent the offer id
+        }
+        return false;
+    }
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
     static class Properties {
         @JsonProperty("https://w3id.org/edc/v0.0.1/ns/cid")

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/models/edc/DataPlaneEndpoint.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/models/edc/DataPlaneEndpoint.java
@@ -40,15 +40,11 @@ public class DataPlaneEndpoint {
     @JsonProperty("authCode")
     String authCode;
 
-    @JsonProperty("properties")
-    Properties properties;
-
-    public DataPlaneEndpoint(String id, String endpoint, String authKey, String authCode, Properties properties) {
+    public DataPlaneEndpoint(String id, String endpoint, String authKey, String authCode) {
         this.id = id;
         this.endpoint = endpoint;
         this.authKey = authKey;
         this.authCode = authCode;
-        this.properties = properties;
     }
 
     public DataPlaneEndpoint() {
@@ -85,28 +81,4 @@ public class DataPlaneEndpoint {
     public void setAuthCode(String authCode) {
         this.authCode = authCode;
     }
-
-    public Properties getProperties() {
-        return properties;
-    }
-
-    public void setProperties(Properties properties) {
-        this.properties = properties;
-    }
-
-    public void setOfferId(String offerId) {
-        this.properties.offerId = offerId;
-    }
-
-    public String getOfferId() {
-        return this.properties.offerId;
-    }
-
-    static class Properties {
-        @JsonProperty("https://w3id.org/edc/v0.0.1/ns/cid")
-        String offerId;
-
-    }
-
-
 }

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/models/edc/DataPlaneEndpoint.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/models/edc/DataPlaneEndpoint.java
@@ -25,8 +25,10 @@
 
 package org.eclipse.tractusx.productpass.models.edc;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class DataPlaneEndpoint {
     @JsonProperty("id")
     String id;
@@ -102,6 +104,7 @@ public class DataPlaneEndpoint {
         return this.properties.offerId;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     static class Properties {
         @JsonProperty("https://w3id.org/edc/v0.0.1/ns/cid")
         String offerId;

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/models/negotiation/Transfer.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/models/negotiation/Transfer.java
@@ -46,7 +46,6 @@ public class Transfer extends DidDocument{
     @JsonProperty("edc:dataDestination")
     DataDestination dataDestination;
 
-
     @JsonProperty("edc:dataRequest")
     DataRequest dataRequest;
 
@@ -170,11 +169,14 @@ public class Transfer extends DidDocument{
     public void setErrorDetail(String errorDetail) {
         this.errorDetail = errorDetail;
     }
-
-
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     static class DataRequest extends DidDocument{
         @JsonProperty("edc:assetId")
         String assetId;
+
+        @JsonProperty("edc:connectorId")
+        String connectorId;
+
         @JsonProperty("edc:contractId")
         String contractId;
 
@@ -193,8 +195,16 @@ public class Transfer extends DidDocument{
         public void setContractId(String contractId) {
             this.contractId = contractId;
         }
-    }
 
+        public String getConnectorId() {
+            return connectorId;
+        }
+
+        public void setConnectorId(String connectorId) {
+            this.connectorId = connectorId;
+        }
+    }
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     static class DataDestination {
         @JsonProperty("edc:type")
         String type;

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/models/negotiation/TransferRequest.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/models/negotiation/TransferRequest.java
@@ -38,6 +38,9 @@ public class TransferRequest {
     String assetId;
     @JsonProperty("connectorAddress")
     String connectorAddress;
+
+    @JsonProperty("connectorId")
+    String connectorId;
     @JsonProperty("contractId")
     String contractId;
     @JsonProperty("dataDestination")
@@ -51,19 +54,21 @@ public class TransferRequest {
     @JsonProperty("transferType")
     TransferType transferType;
 
-    public TransferRequest(JsonNode context, String assetId, String connectorAddress, String contractId, DataDestination dataDestination, Boolean managedResources, PrivateProperties privateProperties, String protocol, TransferType transferType) {
+
+    public TransferRequest() {
+    }
+
+    public TransferRequest(JsonNode context, String assetId, String connectorAddress, String connectorId, String contractId, DataDestination dataDestination, Boolean managedResources, PrivateProperties privateProperties, String protocol, TransferType transferType) {
         this.context = context;
         this.assetId = assetId;
         this.connectorAddress = connectorAddress;
+        this.connectorId = connectorId;
         this.contractId = contractId;
         this.dataDestination = dataDestination;
         this.managedResources = managedResources;
         this.privateProperties = privateProperties;
         this.protocol = protocol;
         this.transferType = transferType;
-    }
-
-    public TransferRequest() {
     }
 
     public JsonNode getContext() {
@@ -139,6 +144,14 @@ public class TransferRequest {
         this.transferType = transferType;
     }
 
+    public String getConnectorId() {
+        return connectorId;
+    }
+
+    public void setConnectorId(String connectorId) {
+        this.connectorId = connectorId;
+    }
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class TransferType{
         @JsonProperty("contentType")
@@ -164,14 +177,14 @@ public class TransferRequest {
     }
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class DataDestination {
-        @JsonProperty("properties")
-        Properties properties;
+        @JsonProperty("type")
+        String properties;
 
-        public Properties getProperties() {
+        public String getProperties() {
             return properties;
         }
 
-        public void setProperties(Properties properties) {
+        public void setProperties(String properties) {
             this.properties = properties;
         }
     }

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/models/negotiation/TransferRequest.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/models/negotiation/TransferRequest.java
@@ -178,14 +178,15 @@ public class TransferRequest {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class DataDestination {
         @JsonProperty("type")
-        String properties;
+        String type;
 
-        public String getProperties() {
-            return properties;
+
+        public String getType() {
+            return type;
         }
 
-        public void setProperties(String properties) {
-            this.properties = properties;
+        public void setType(String type) {
+            this.type = type;
         }
     }
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/services/DataTransferService.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/services/DataTransferService.java
@@ -204,7 +204,7 @@ public class DataTransferService extends BaseService {
                 transferType.setIsFinite(true);
 
                 TransferRequest.DataDestination dataDestination = new TransferRequest.DataDestination();
-                dataDestination.setProperties(new Properties("HttpProxy"));
+                dataDestination.setProperties("HttpProxy");
 
                 TransferRequest.PrivateProperties privateProperties = new TransferRequest.PrivateProperties();
                 privateProperties.setReceiverHttpEndpoint(receiverEndpoint);
@@ -212,6 +212,7 @@ public class DataTransferService extends BaseService {
                         jsonUtil.toJsonNode(Map.of("odrl", "http://www.w3.org/ns/odrl/2/")),
                         dataset.getAssetId(),
                         status.getEndpoint(),
+                        bpnNumber,
                         negotiation.getContractAgreementId(),
                         dataDestination,
                         false,

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/services/DataTransferService.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/services/DataTransferService.java
@@ -203,8 +203,9 @@ public class DataTransferService extends BaseService {
                 transferType.setContentType("application/octet-stream");
                 transferType.setIsFinite(true);
 
+
                 TransferRequest.DataDestination dataDestination = new TransferRequest.DataDestination();
-                dataDestination.setProperties("HttpProxy");
+                dataDestination.setType("HttpProxy");
 
                 TransferRequest.PrivateProperties privateProperties = new TransferRequest.PrivateProperties();
                 privateProperties.setReceiverHttpEndpoint(receiverEndpoint);

--- a/consumer-backend/productpass/src/main/java/utils/CrypUtil.java
+++ b/consumer-backend/productpass/src/main/java/utils/CrypUtil.java
@@ -39,7 +39,6 @@ import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.UUID;
 
 import javax.crypto.Cipher;
@@ -67,6 +66,10 @@ public final class CrypUtil {
     }
     public static String fromBase64Url(String base64){
         return new String(Base64.getUrlDecoder().decode(base64));
+    }
+
+    public static Boolean isBase64(String str){
+        return org.apache.commons.net.util.Base64.isArrayByteBase64(str.getBytes()); // Check if string is Base64 encoded
     }
 
     public static String getUUID(){

--- a/consumer-backend/productpass/src/main/java/utils/EdcUtil.java
+++ b/consumer-backend/productpass/src/main/java/utils/EdcUtil.java
@@ -46,5 +46,17 @@ public class EdcUtil {
         }
     }
 
+    // This method is responsible for finding if the EDC is version v0.5.0 basing itself in the contractId format.
+    public Boolean isEdc5(String contractId){
+        try {
+            String[] parts = contractId.split(String.format("\\%s",":"));
+            if(parts.length != 3){
+                throw new UtilException(EdcUtil.class, "It was not possible to check if EDC is v0.5.0, Invalid Contract Id");
+            }
+            return CrypUtil.isBase64(parts[1]); // If the contractId is base64 encoded
+        }catch (Exception e){
+            throw new UtilException(EdcUtil.class, e, "It was not possible check if is the EDC v0.5.0");
+        }
+    }
 
 }

--- a/consumer-backend/productpass/src/main/java/utils/HttpUtil.java
+++ b/consumer-backend/productpass/src/main/java/utils/HttpUtil.java
@@ -184,7 +184,6 @@ public class HttpUtil {
 
             String header = CrypUtil.fromBase64Url(chunks[0]);
             String payload = CrypUtil.fromBase64Url(chunks[1]);
-            LogUtil.printMessage("token header: " + header + " payload: " + payload);
             jwt.setHeader((Map<String, Object>) jsonUtil.parseJson(header));
             jwt.setPayload((Map<String, Object>) jsonUtil.parseJson(payload));
             return jwt;

--- a/consumer-backend/productpass/src/main/java/utils/PassportUtil.java
+++ b/consumer-backend/productpass/src/main/java/utils/PassportUtil.java
@@ -25,6 +25,8 @@
 
 package utils;
 
+import org.eclipse.tractusx.productpass.exceptions.ManagerException;
+import org.eclipse.tractusx.productpass.managers.ProcessManager;
 import org.eclipse.tractusx.productpass.models.edc.DataPlaneEndpoint;
 import org.eclipse.tractusx.productpass.models.edc.Jwt;
 import org.eclipse.tractusx.productpass.models.passports.Passport;
@@ -42,14 +44,14 @@ public class PassportUtil {
     private final FileUtil fileUtil;
     private final String transferDir;
 
-    private final HttpUtil httpUtil;
+    private final ProcessManager processManager;
 
     @Autowired
-    public PassportUtil(JsonUtil jsonUtil, FileUtil fileUtil,HttpUtil httpUtil, Environment env) {
+    public PassportUtil(JsonUtil jsonUtil, FileUtil fileUtil,ProcessManager processManager, Environment env) {
         this.transferDir = env.getProperty("passport.dataTransfer.dir", String.class, "data/transfer");
         this.jsonUtil = jsonUtil;
         this.fileUtil = fileUtil;
-        this.httpUtil = httpUtil;
+        this.processManager = processManager;
     }
     public String savePassport(Passport passport, DataPlaneEndpoint endpointData, Boolean prettyPrint, Boolean encrypted){
         try {
@@ -66,8 +68,12 @@ public class PassportUtil {
             if(!encrypted) {
                 return jsonUtil.toJsonFile(filePath, passport, prettyPrint); // Store the plain JSON
             }else{
-                Jwt token = httpUtil.parseToken(endpointData.getAuthCode());
-                return fileUtil.toFile(filePath, CrypUtil.encryptAes(jsonUtil.toJson(passport, prettyPrint), token.getPayload().get("cid")+endpointData.getId()), false); // Store Encrypted
+                // Get token content or the contractID from properties
+                String contractId = processManager.getContractId(endpointData);
+                if(contractId == null){
+                    throw new UtilException(PassportUtil.class, "The Contract Id is null! It was not possible to save the passport!");
+                }
+                return fileUtil.toFile(filePath, CrypUtil.encryptAes(jsonUtil.toJson(passport, prettyPrint), contractId+endpointData.getId()), false); // Store Encrypted
             }
         }catch (Exception e){
             throw new UtilException(PassportUtil.class, e, "Something went wrong while saving the passport for transfer ["+endpointData.getId()+"]");

--- a/deployment/helm/edc-consumer/Chart.yaml
+++ b/deployment/helm/edc-consumer/Chart.yaml
@@ -26,15 +26,15 @@ description: |
   A Helm chart for Tractus-X Eclipse Data Space Connector. This chart is a test mock that can be used as edc consumer for the DPP applicatiton.
 type: application
 version: 0.3.3
-appVersion: "0.4.1"
+appVersion: "0.5.0-rc4"
 home: https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector
 sources:
   - https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector
 urls:
-  - https://github.com/eclipse-tractusx/tractusx-edc/releases/download/tractusx-connector-0.4.1/tractusx-connector-0.4.1.tgz
+  - https://github.com/eclipse-tractusx/tractusx-edc/releases/download/tractusx-connector-0.5.0/tractusx-connector-0.5.0.tgz
 dependencies:
   - name: tractusx-connector
-    version: 0.4.1
+    version: "0.5.0-rc4"
     repository: https://eclipse-tractusx.github.io/charts/dev
     condition: enabled
   - name: postgresql

--- a/deployment/helm/edc-consumer/Chart.yaml
+++ b/deployment/helm/edc-consumer/Chart.yaml
@@ -26,7 +26,7 @@ description: |
   A Helm chart for Tractus-X Eclipse Data Space Connector. This chart is a test mock that can be used as edc consumer for the DPP applicatiton.
 type: application
 version: 0.3.3
-appVersion: "0.5.0-rc4"
+appVersion: "0.5.0"
 home: https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector
 sources:
   - https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector
@@ -34,7 +34,7 @@ urls:
   - https://github.com/eclipse-tractusx/tractusx-edc/releases/download/tractusx-connector-0.5.0/tractusx-connector-0.5.0.tgz
 dependencies:
   - name: tractusx-connector
-    version: "0.5.0-rc4"
+    version: "0.5.0"
     repository: https://eclipse-tractusx.github.io/charts/dev
     condition: enabled
   - name: postgresql

--- a/deployment/helm/edc-consumer/values-beta.yaml
+++ b/deployment/helm/edc-consumer/values-beta.yaml
@@ -33,7 +33,7 @@
 tractusx-connector:
   enabled: true
   participant:
-    id: &bpnNumber "<path:material-pass/data/beta/edc/participant#bpnNumber>"
+    id: "<path:material-pass/data/beta/edc/participant#bpnNumber>"
 
   controlplane:
     enabled: true
@@ -78,6 +78,18 @@ tractusx-connector:
         path: /consumer/observability
         # -- allow or disallow insecure access, i.e. access without authentication
         insecure: true
+
+    ssi:
+      miw:
+        url: "<path:material-pass/data/beta/edc/ssi#miwUrl>"
+        authorityId: "<path:material-pass/data/beta/edc/ssi#authorityId>"
+      oauth:
+        tokenurl: "https://centralidp.beta.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+        client:
+          id: "<path:material-pass/data/beta/edc/ssi#clientId>"
+          secretAlias: "beta-client-secret"
+      endpoint:
+        audience: https://materialpass.beta.demo.catena-x.net/consumer
 
     ## Ingress declaration to expose the network service.
     ingresses:
@@ -174,31 +186,10 @@ tractusx-connector:
       transferProxyTokenSignerPrivateKey: ids-daps_key
       transferProxyTokenSignerPublicKey: ids-daps_crt
       transferProxyTokenEncryptionAesKey: edc-encryption-key
-      dapsPrivateKey: ids-daps_key
-      dapsPublicKey: ids-daps_crt
-
-  daps:
-    fullnameOverride: "daps"
-    url: "https://daps.beta.demo.catena-x.net"
-    clientId: <path:material-pass/data/beta/edc/oauth#client.id>
-    paths:
-      jwks: /.well-known/jwks.json
-      token: /token
-    connectors:
-      - id: <path:material-pass/data/beta/edc/oauth#client.id>
-        name: edcconector
-        attributes:
-          referringConnector: "https://materialpass.beta.demo.catena-x.net/consumer/<path:material-pass/data/beta/edc/participant#bpnNumber>"
-        # Must be the same certificate that is stores in section 'sokrates-vault'
-        certificate: <path:material-pass/data/ids-daps_crt#content>
 
   backendService:
      httpProxyTokenReceiverUrl: "https://materialpass.beta.demo.catena-x.net/endpoint"
     
-  idsdaps:
-    connectors:
-      - certificate: <path:material-pass/data/ids-daps_crt#content>
-
 postgresql:
   auth:
     username: <path:material-pass/data/beta/edc/database#user>

--- a/deployment/helm/edc-consumer/values-int.yaml
+++ b/deployment/helm/edc-consumer/values-int.yaml
@@ -33,7 +33,7 @@
 tractusx-connector:
   enabled: true
   participant:
-    id: &bpnNumber "<path:material-pass/data/int/edc/participant#bpnNumber>"
+    id: "<path:material-pass/data/int/edc/participant#bpnNumber>"
 
   controlplane:
     enabled: true
@@ -78,6 +78,18 @@ tractusx-connector:
         path: /consumer/observability
         # -- allow or disallow insecure access, i.e. access without authentication
         insecure: true
+
+    ssi:
+      miw:
+        url: "<path:material-pass/data/int/edc/ssi#miwUrl>"
+        authorityId: "<path:material-pass/data/int/edc/ssi#authorityId>"
+      oauth:
+        tokenurl: "https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+        client:
+          id: "<path:material-pass/data/int/edc/ssi#clientId>"
+          secretAlias: "int-client-secret"
+      endpoint:
+        audience: https://materialpass.int.demo.catena-x.net/consumer
 
     ## Ingress declaration to expose the network service.
     ingresses:
@@ -160,7 +172,6 @@ tractusx-connector:
     password: <path:material-pass/data/int/edc/database#user>
 
   vault:
-   
     hashicorp:
       url: <path:material-pass/data/int/edc/vault#vault.hashicorp.url>
       token: <path:material-pass/data/int/edc/vault#vault.hashicorp.token>
@@ -171,30 +182,9 @@ tractusx-connector:
       transferProxyTokenSignerPrivateKey: ids-daps_key
       transferProxyTokenSignerPublicKey: ids-daps_crt
       transferProxyTokenEncryptionAesKey: edc-encryption-key
-      dapsPrivateKey: ids-daps_key
-      dapsPublicKey: ids-daps_crt
-
-  daps:
-    fullnameOverride: "daps"
-    url: "https://daps1.int.demo.catena-x.net"
-    clientId: <path:material-pass/data/int/edc/oauth#client.id>
-    paths:
-      jwks: /.well-known/jwks.json
-      token: /token
-    connectors:
-      - id: <path:material-pass/data/int/edc/oauth#client.id>
-        name: edcconector
-        attributes:
-          referringConnector: "https://materialpass.int.demo.catena-x.net/consumer/<path:material-pass/data/int/edc/participant#bpnNumber>"
-        # Must be the same certificate that is stores in section 'sokrates-vault'
-        certificate: <path:material-pass/data/ids-daps_crt#content>
 
   backendService:
      httpProxyTokenReceiverUrl: "https://materialpass.int.demo.catena-x.net/endpoint"
-    
-  idsdaps:
-    connectors:
-      - certificate: <path:material-pass/data/ids-daps_crt#content>
 
 postgresql:
   auth:

--- a/deployment/helm/edc-consumer/values.yaml
+++ b/deployment/helm/edc-consumer/values.yaml
@@ -43,7 +43,7 @@ tractusx-connector:
 
     
   participant:
-    id: &bpnNumber "<path:material-pass/data/dev/edc/participant#bpnNumber>"
+    id: "<path:material-pass/data/dev/edc/participant#bpnNumber>"
 
   controlplane:
     enabled: true
@@ -549,8 +549,6 @@ tractusx-connector:
       transferProxyTokenSignerPrivateKey: daps-key-dev
       transferProxyTokenSignerPublicKey: daps-crt-dev
       transferProxyTokenEncryptionAesKey: edc-encryption-key
-      dapsPrivateKey: daps-key-dev
-      dapsPublicKey: daps-crt-dev
 
   backendService:
     httpProxyTokenReceiverUrl: "https://materialpass.dev.demo.catena-x.net/endpoint"
@@ -596,5 +594,5 @@ postgresql:
       enabled: true
   auth:
     database: "edc"
-    username: <path:material-pass/data/int/edc/database#user>
-    password: <path:material-pass/data/int/edc/database#password>
+    username: <path:material-pass/data/dev/edc/database#user>
+    password: <path:material-pass/data/dev/edc/database#password>

--- a/deployment/helm/edc-consumer/values.yaml
+++ b/deployment/helm/edc-consumer/values.yaml
@@ -143,7 +143,7 @@ tractusx-connector:
         url: "<path:material-pass/data/dev/edc/ssi#miwUrl>"
         authorityId: "<path:material-pass/data/dev/edc/ssi#authorityId>"
       oauth:
-        tokenurl: "https://centralidp.dev.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+        tokenurl: "https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
         client:
           id: "<path:material-pass/data/dev/edc/ssi#clientId>"
           secretAlias: "dev-client-secret"

--- a/deployment/helm/edc-consumer/values.yaml
+++ b/deployment/helm/edc-consumer/values.yaml
@@ -147,7 +147,9 @@ tractusx-connector:
         client:
           id: "<path:material-pass/data/dev/edc/ssi#clientId>"
           secretAlias: "dev-client-secret"
-
+      endpoint:
+        audience: https://materialpass.dev.demo.catena-x.net/consumer
+        
     service:
       # -- [Service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to expose the running application on a set of Pods as a network service.
       type: ClusterIP

--- a/deployment/helm/edc-consumer/values.yaml
+++ b/deployment/helm/edc-consumer/values.yaml
@@ -145,7 +145,7 @@ tractusx-connector:
       oauth:
         tokenurl: "https://centralidp.dev.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
         client:
-          id: "<path:material-pass/data/dev/aasregistry#client.id>"
+          id: "<path:material-pass/data/dev/edc/ssi#clientId>"
           secretAlias: "dev-client-secret"
 
     service:

--- a/deployment/helm/edc-consumer/values.yaml
+++ b/deployment/helm/edc-consumer/values.yaml
@@ -53,7 +53,7 @@ tractusx-connector:
       # -- [Kubernetes image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) to use
       pullPolicy: IfNotPresent
       # -- Overrides the image tag whose default is the chart appVersion
-      tag: "0.4.1"
+      tag: "0.5.0-rc4"
     initContainers: []
     debug:
       enabled: false
@@ -137,6 +137,17 @@ tractusx-connector:
     businessPartnerValidation:
       log:
         agreementValidation: true
+          # SSI configuration
+    ssi:
+      miw:
+        url: "<path:material-pass/data/dev/edc/ssi#miwUrl>"
+        authorityId: "<path:material-pass/data/dev/edc/ssi#authorityId>"
+      oauth:
+        tokenurl: "https://centralidp.dev.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+        client:
+          id: "<path:material-pass/data/dev/aasregistry#client.id>"
+          secretAlias: "dev-client-secret"
+
     service:
       # -- [Service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to expose the running application on a set of Pods as a network service.
       type: ClusterIP
@@ -308,7 +319,7 @@ tractusx-connector:
       # -- [Kubernetes image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) to use
       pullPolicy: IfNotPresent
       # -- Overrides the image tag whose default is the chart appVersion
-      tag: "0.4.1"
+      tag: "0.5.0-rc4"
     initContainers: []
     debug:
       enabled: false
@@ -539,23 +550,22 @@ tractusx-connector:
       dapsPrivateKey: daps-key-dev
       dapsPublicKey: daps-crt-dev
 
-  daps:
-    fullnameOverride: "daps"
-    url: "https://daps1.int.demo.catena-x.net"
-    clientId: <path:material-pass/data/dev/edc/oauth#client.id>
-    paths:
-      jwks: /.well-known/jwks.json
-      token: /token
-    connectors:
-      - id: <path:material-pass/data/dev/edc/oauth#client.id>
-        name: edcconector
-        attributes:
-          referringConnector: "https://materialpass.dev.demo.catena-x.net/consumer/<path:material-pass/data/dev/edc/participant#bpnNumber>"
-        certificate: <path:material-pass/data/daps-crt-dev#content>
-
-
   backendService:
     httpProxyTokenReceiverUrl: "https://materialpass.dev.demo.catena-x.net/endpoint"
+
+  networkPolicy:
+    # -- If `true` network policy will be created to restrict access to control- and dataplane
+    enabled: false
+    # -- Configuration of the controlplane component
+    controlplane:
+      # -- Specify from rule network policy for cp (defaults to all namespaces)
+      from:
+      - namespaceSelector: {}
+    # -- Configuration of the dataplane component
+    dataplane:
+      # -- Specify from rule network policy for dp (defaults to all namespaces)
+      from:
+      - namespaceSelector: {}
 
   serviceAccount:
     # Specifies whether a service account should be created
@@ -567,10 +577,11 @@ tractusx-connector:
     name: ""
     # -- Existing image pull secret bound to the service account to use to [obtain the container image from private registries](https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry)
     imagePullSecrets: []
-    
-  idsdaps:
-    connectors:
-      - certificate: <path:material-pass/data/daps-crt-dev#content>
+
+  # -- Configurations for Helm tests
+  tests:
+    # -- Configure the hook-delete-policy for Helm tests
+    hookDeletePolicy: before-hook-creation,hook-succeeded
 
 postgresql:
   jdbcUrl: "jdbc:postgresql://postgresql:5432/edc"

--- a/deployment/helm/edc-consumer/values.yaml
+++ b/deployment/helm/edc-consumer/values.yaml
@@ -53,7 +53,7 @@ tractusx-connector:
       # -- [Kubernetes image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) to use
       pullPolicy: IfNotPresent
       # -- Overrides the image tag whose default is the chart appVersion
-      tag: "0.5.0-rc4"
+      tag: "0.5.0"
     initContainers: []
     debug:
       enabled: false
@@ -321,7 +321,7 @@ tractusx-connector:
       # -- [Kubernetes image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) to use
       pullPolicy: IfNotPresent
       # -- Overrides the image tag whose default is the chart appVersion
-      tag: "0.5.0-rc4"
+      tag: "0.5.0"
     initContainers: []
     debug:
       enabled: false

--- a/deployment/helm/edc-provider/Chart.yaml
+++ b/deployment/helm/edc-provider/Chart.yaml
@@ -27,15 +27,15 @@ description: |
   A Helm chart for Tractus-X Eclipse Data Space Connector. This chart is a test mock that can be used as edc provider for the DPP applicatiton.
 type: application
 version: 0.3.3
-appVersion: "0.4.1"
+appVersion: "0.5.0-rc4"
 home: https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector
 sources:
   - https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector
 urls:
-  - https://github.com/eclipse-tractusx/tractusx-edc/releases/download/tractusx-connector-0.4.0/tractusx-connector-0.4.0.tgz
+  - https://github.com/eclipse-tractusx/tractusx-edc/releases/download/tractusx-connector-0.5.0/tractusx-connector-0.5.0.tgz
 dependencies:
   - name: tractusx-connector
-    version: 0.4.1
+    version: "0.5.0-rc4"
     repository: https://eclipse-tractusx.github.io/charts/dev
     condition: enabled
   - name: postgresql

--- a/deployment/helm/edc-provider/Chart.yaml
+++ b/deployment/helm/edc-provider/Chart.yaml
@@ -31,8 +31,6 @@ appVersion: "0.5.0"
 home: https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector
 sources:
   - https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector
-urls:
-  - https://github.com/eclipse-tractusx/tractusx-edc/releases/download/tractusx-connector-0.5.0/tractusx-connector-0.5.0.tgz
 dependencies:
   - name: tractusx-connector
     version: "0.5.0"

--- a/deployment/helm/edc-provider/Chart.yaml
+++ b/deployment/helm/edc-provider/Chart.yaml
@@ -27,7 +27,7 @@ description: |
   A Helm chart for Tractus-X Eclipse Data Space Connector. This chart is a test mock that can be used as edc provider for the DPP applicatiton.
 type: application
 version: 0.3.3
-appVersion: "0.5.0-rc4"
+appVersion: "0.5.0"
 home: https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector
 sources:
   - https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector
@@ -35,7 +35,7 @@ urls:
   - https://github.com/eclipse-tractusx/tractusx-edc/releases/download/tractusx-connector-0.5.0/tractusx-connector-0.5.0.tgz
 dependencies:
   - name: tractusx-connector
-    version: "0.5.0-rc4"
+    version: "0.5.0"
     repository: https://eclipse-tractusx.github.io/charts/dev
     condition: enabled
   - name: postgresql

--- a/deployment/helm/edc-provider/values-beta.yaml
+++ b/deployment/helm/edc-provider/values-beta.yaml
@@ -28,7 +28,7 @@
 tractusx-connector:
   enabled: true
   participant:
-    id: &bpnNumber "<path:material-pass/data/beta/edc/participant#bpnNumber>"
+    id: "<path:material-pass/data/beta/edc/participant#bpnNumber>"
 
   controlplane:
     enabled: true
@@ -73,6 +73,18 @@ tractusx-connector:
         path: /BPNL000000000000/observability
         # -- allow or disallow insecure access, i.e. access without authentication
         insecure: true
+    
+    ssi:
+      miw:
+        url: "<path:material-pass/data/beta/edc/ssi#miwUrl>"
+        authorityId: "<path:material-pass/data/beta/edc/ssi#authorityId>"
+      oauth:
+        tokenurl: "https://centralidp.beta.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+        client:
+          id: "<path:material-pass/data/beta/edc/ssi#clientId>"
+          secretAlias: "beta-client-secret"
+      endpoint:
+        audience: https://materialpass.beta.demo.catena-x.net/BPNL000000000000
 
     ## Ingress declaration to expose the network service.
     ingresses:
@@ -80,8 +92,7 @@ tractusx-connector:
       - enabled: true
         # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
         hostname: "materialpass.beta.demo.catena-x.net"
-        # -- Additional ingress annotations to add
-        # -- Additional ingress annotations to add
+       # -- Additional ingress annotations to add
         annotations: {}
         # -- EDC endpoints exposed by this ingress resource
         endpoints:
@@ -131,7 +142,7 @@ tractusx-connector:
         # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
         hostname: "materialpass.beta.demo.catena-x.net"
         # -- Additional ingress annotations to add
-                # -- Additional ingress annotations to add
+               # -- Additional ingress annotations to add
         annotations: {}
         # -- EDC endpoints exposed by this ingress resource
         endpoints:
@@ -150,7 +161,6 @@ tractusx-connector:
           issuer: ""
           # -- If preset enables certificate generation via cert-manager cluster-wide issuer
           clusterIssuer: ""
-       
   postgresql:
     username: <path:material-pass/data/beta/edc/database#user>
     password: <path:material-pass/data/beta/edc/database#user>
@@ -161,7 +171,7 @@ tractusx-connector:
   vault:
     fullnameOverride: "vault"
     hashicorp:
-      url: <path:material-pass/data/beta/edc/vault#vault.hashicorp.url>
+      url: <path:material-pass/data/int/beta/vault#vault.hashicorp.url>
       token: <path:material-pass/data/beta/edc/vault#vault.hashicorp.token>
       paths:
         secret: <path:material-pass/data/beta/edc/vault#vault.hashicorp.api.secret.path>
@@ -170,25 +180,10 @@ tractusx-connector:
       transferProxyTokenSignerPrivateKey: ids-daps_key
       transferProxyTokenSignerPublicKey: ids-daps_crt
       transferProxyTokenEncryptionAesKey: edc-encryption-key
-      dapsPrivateKey: ids-daps_key
-      dapsPublicKey: ids-daps_crt
-
-  daps:
-    url: "https://daps.beta.demo.catena-x.net"
-    clientId: <path:material-pass/data/beta/edc/oauth#client.id>
-    connectors:
-      - id: <path:material-pass/data/beta/edc/oauth#client.id>
-        name: edcconector
-        attributes:
-          referringConnector: "https://materialpass.beta.demo.catena-x.net/consumer/<path:material-pass/data/beta/edc/participant#bpnNumber>"
-        certificate: <path:material-pass/data/ids-daps_crt#content>
 
   backendService:
     httpProxyTokenReceiverUrl: "https://materialpass.beta.demo.catena-x.net/endpoint"
     
-  idsdaps:
-    connectors:
-      - certificate: <path:material-pass/data/ids-daps_crt#content>
 
 postgresql:
   auth:

--- a/deployment/helm/edc-provider/values-int.yaml
+++ b/deployment/helm/edc-provider/values-int.yaml
@@ -28,7 +28,7 @@
 tractusx-connector:
   enabled: true
   participant:
-    id: &bpnNumber "<path:material-pass/data/int/edc/participant#bpnNumber>"
+    id: "<path:material-pass/data/int/edc/participant#bpnNumber>"
 
   controlplane:
     enabled: true
@@ -73,6 +73,18 @@ tractusx-connector:
         path: /BPNL000000000000/observability
         # -- allow or disallow insecure access, i.e. access without authentication
         insecure: true
+    
+    ssi:
+      miw:
+        url: "<path:material-pass/data/int/edc/ssi#miwUrl>"
+        authorityId: "<path:material-pass/data/int/edc/ssi#authorityId>"
+      oauth:
+        tokenurl: "https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+        client:
+          id: "<path:material-pass/data/int/edc/ssi#clientId>"
+          secretAlias: "int-client-secret"
+      endpoint:
+        audience: https://materialpass.int.demo.catena-x.net/BPNL000000000000
 
     ## Ingress declaration to expose the network service.
     ingresses:
@@ -168,25 +180,10 @@ tractusx-connector:
       transferProxyTokenSignerPrivateKey: ids-daps_key
       transferProxyTokenSignerPublicKey: ids-daps_crt
       transferProxyTokenEncryptionAesKey: edc-encryption-key
-      dapsPrivateKey: ids-daps_key
-      dapsPublicKey: ids-daps_crt
-
-  daps:
-    url: "https://daps1.int.demo.catena-x.net"
-    clientId: <path:material-pass/data/int/edc/oauth#client.id>
-    connectors:
-      - id: <path:material-pass/data/int/edc/oauth#client.id>
-        name: edcconector
-        attributes:
-          referringConnector: "https://materialpass.int.demo.catena-x.net/consumer/<path:material-pass/data/int/edc/participant#bpnNumber>"
-        certificate: <path:material-pass/data/ids-daps_crt#content>
 
   backendService:
     httpProxyTokenReceiverUrl: "https://materialpass.int.demo.catena-x.net/endpoint"
     
-  idsdaps:
-    connectors:
-      - certificate: <path:material-pass/data/ids-daps_crt#content>
 
 postgresql:
   auth:

--- a/deployment/helm/edc-provider/values.yaml
+++ b/deployment/helm/edc-provider/values.yaml
@@ -49,7 +49,7 @@ tractusx-connector:
       # -- [Kubernetes image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) to use
       pullPolicy: IfNotPresent
       # -- Overrides the image tag whose default is the chart appVersion
-      tag: "0.5.0-rc4"
+      tag: "0.5.0"
     initContainers: []
     debug:
       enabled: false
@@ -317,7 +317,7 @@ tractusx-connector:
       # -- [Kubernetes image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) to use
       pullPolicy: IfNotPresent
       # -- Overrides the image tag whose default is the chart appVersion
-      tag: "0.5.0-rc4"
+      tag: "0.5.0"
     initContainers: []
     debug:
       enabled: false

--- a/deployment/helm/edc-provider/values.yaml
+++ b/deployment/helm/edc-provider/values.yaml
@@ -39,7 +39,7 @@ tractusx-connector:
 
     
   participant:
-    id: &bpnNumber "<path:material-pass/data/dev/edc/participant#bpnNumber>"
+    id: "<path:material-pass/data/dev/edc/participant#bpnNumber>"
 
   controlplane:
     enabled: true
@@ -545,22 +545,6 @@ tractusx-connector:
       transferProxyTokenSignerPrivateKey: daps-key-dev
       transferProxyTokenSignerPublicKey: daps-crt-dev
       transferProxyTokenEncryptionAesKey: edc-encryption-key
-      dapsPrivateKey: daps-key-dev
-      dapsPublicKey: daps-crt-dev
-
-  daps:
-    fullnameOverride: "daps"
-    url: "https://daps1.int.demo.catena-x.net"
-    clientId: <path:material-pass/data/dev/edc/oauth#client.id>
-    paths:
-      jwks: /.well-known/jwks.json
-      token: /token
-    connectors:
-      - id: <path:material-pass/data/dev/edc/oauth#client.id>
-        name: edcconector
-        attributes:
-          referringConnector: "https://materialpass.dev.demo.catena-x.net/consumer/<path:material-pass/data/dev/edc/participant#bpnNumber>"
-        certificate: <path:material-pass/data/daps-crt-dev#content>
 
   backendService:
     httpProxyTokenReceiverUrl: "https://materialpass.dev.demo.catena-x.net/endpoint"
@@ -576,9 +560,6 @@ tractusx-connector:
     # -- Existing image pull secret bound to the service account to use to [obtain the container image from private registries](https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry)
     imagePullSecrets: []
     
-  idsdaps:
-    connectors:
-      - certificate: <path:material-pass/data/ids-daps_crt#content>
 
 postgresql:
   jdbcUrl: "jdbc:postgresql://postgresqlprovider:5432/edc"

--- a/deployment/helm/edc-provider/values.yaml
+++ b/deployment/helm/edc-provider/values.yaml
@@ -49,7 +49,7 @@ tractusx-connector:
       # -- [Kubernetes image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) to use
       pullPolicy: IfNotPresent
       # -- Overrides the image tag whose default is the chart appVersion
-      tag: "0.4.1"
+      tag: "0.5.0-rc4"
     initContainers: []
     debug:
       enabled: false
@@ -133,6 +133,17 @@ tractusx-connector:
     businessPartnerValidation:
       log:
         agreementValidation: true
+
+    ssi:
+      miw:
+        url: "<path:material-pass/data/dev/edc/ssi#miwUrl>"
+        authorityId: "<path:material-pass/data/dev/edc/ssi#authorityId>"
+      oauth:
+        tokenurl: "https://centralidp.dev.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+        client:
+          id: "<path:material-pass/data/dev/aasregistry#client.id>"
+          secretAlias: "dev-client-secret"
+
     service:
       # -- [Service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to expose the running application on a set of Pods as a network service.
       type: ClusterIP
@@ -304,7 +315,7 @@ tractusx-connector:
       # -- [Kubernetes image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) to use
       pullPolicy: IfNotPresent
       # -- Overrides the image tag whose default is the chart appVersion
-      tag: "0.4.1"
+      tag: "0.5.0-rc4"
     initContainers: []
     debug:
       enabled: false

--- a/deployment/helm/edc-provider/values.yaml
+++ b/deployment/helm/edc-provider/values.yaml
@@ -139,7 +139,7 @@ tractusx-connector:
         url: "<path:material-pass/data/dev/edc/ssi#miwUrl>"
         authorityId: "<path:material-pass/data/dev/edc/ssi#authorityId>"
       oauth:
-        tokenurl: "https://centralidp.dev.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+        tokenurl: "https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
         client:
           id: "<path:material-pass/data/dev/edc/ssi#clientId>"
           secretAlias: "dev-client-secret"

--- a/deployment/helm/edc-provider/values.yaml
+++ b/deployment/helm/edc-provider/values.yaml
@@ -143,8 +143,9 @@ tractusx-connector:
         client:
           id: "<path:material-pass/data/dev/edc/ssi#clientId>"
           secretAlias: "dev-client-secret"
-
-
+      endpoint:
+        audience: https://materialpass.dev.demo.catena-x.net/consumer
+        
     service:
       # -- [Service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to expose the running application on a set of Pods as a network service.
       type: ClusterIP

--- a/deployment/helm/edc-provider/values.yaml
+++ b/deployment/helm/edc-provider/values.yaml
@@ -141,8 +141,9 @@ tractusx-connector:
       oauth:
         tokenurl: "https://centralidp.dev.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
         client:
-          id: "<path:material-pass/data/dev/aasregistry#client.id>"
+          id: "<path:material-pass/data/dev/edc/ssi#clientId>"
           secretAlias: "dev-client-secret"
+
 
     service:
       # -- [Service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to expose the running application on a set of Pods as a network service.


### PR DESCRIPTION
# Why we create this PR?
 
There is a requirement for the release 3.2 from Catena-X that is to integrate the EDC v0.5.0 in the application.
 
# What we want to achieve with this PR?
 
We want to integrate the new `EDC v0.5.0` in the application, therefore the digital product pass app needs to be able to retrieve and display passports using the new EDC and be able to be compatible with the older version `v0.4.1`
 
# What is new?
 
## Added
- Added new models related with the `EDC v0.5.0` upgrade
- Added backend compatibility with `EDC v0.4.1`

## Updated
- Updated the EDC helm charts to match the necessary configuration for the new version. 
- Configured the SSI in the EDC helm charts
- Updated Passport storage and how the contract id key is obtained from the EDR.
- Updated transfer models.

## PR Linked to:

| Tickets |
| :---:   |
| [cmp-740](https://jira.catena-x.net/browse/CMP-740) |