### PR TITLE
feature/cmp-725/remove-env-charts: added env yaml values files in .he…

### DIFF
--- a/charts/digital-product-pass/.helmignore
+++ b/charts/digital-product-pass/.helmignore
@@ -21,3 +21,6 @@
 .idea/
 *.tmproj
 .vscode/
+# Accept only values.yaml
+values?*.yaml
+values?*.yml

--- a/charts/digital-product-pass/Chart.yaml
+++ b/charts/digital-product-pass/Chart.yaml
@@ -22,8 +22,11 @@
 ---
 apiVersion: v2
 name: digital-product-pass
-description: A Helm chart for Kubernetes
-
+description: 
+    A Helm chart for Tractus-X Digital Product Pass Kubernetes
+home: https://github.com/eclipse-tractusx/digital-product-pass/tree/main/charts/digital-product-pass
+sources:
+  - https://github.com/eclipse-tractusx/digital-product-pass/tree/main/charts/digital-product-pass
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives


### PR DESCRIPTION
…lmignore and added missing home and sources values in chart.yaml

# Why we create this PR?
 
There is a requirement to remove environmental chart values files from the released chart bundle [TRG 5.01](https://github.com/eclipse-tractusx/digital-product-pass/issues/37)
 
# What we want to achieve with this PR?
 
Remove the following file from be included in the released chart bundle:
- values-beta.yaml
- values-int.yaml
- values-dev.yaml
 
# What is new?
 
Added the following code in .helmignore file:
```
# Accept only values.yaml
values?*.yaml
values?*.yml
```
In addition added the following missing variables in Chart.yaml file:
```
- home
- sources
```

## PR Linked to:

| Tickets |
| :---:   |
| [cmp-725](https://jira.catena-x.net/browse/CMP-725) |