### PR TITLE
feature/cmp 591/login bpn: Added check for technical login under other BPN, and EDC check.

### DIFF
--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/listeners/AppListener.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/listeners/AppListener.java
@@ -24,12 +24,19 @@
 package org.eclipse.tractusx.productpass.listeners;
 
 import jakarta.servlet.http.HttpServletRequest;
+import org.eclipse.tractusx.productpass.Application;
+import org.eclipse.tractusx.productpass.http.controllers.api.ContractController;
 import org.eclipse.tractusx.productpass.managers.ProcessDataModel;
 import org.eclipse.tractusx.productpass.managers.ProcessManager;
+import org.eclipse.tractusx.productpass.models.http.requests.Search;
+import org.eclipse.tractusx.productpass.services.DataTransferService;
+import org.eclipse.tractusx.productpass.services.VaultService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.IncompatibleConfigurationException;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.EventListener;
@@ -49,21 +56,51 @@ import utils.LogUtil;
 public class AppListener {
     @Autowired
     BuildProperties buildProperties;
+    @Autowired
+    VaultService vaultService;
+    @Autowired
+    Environment env;
+    @Autowired
+    DataTransferService dataTransferService;
+    @EventListener(ApplicationStartedEvent.class)
+    public void started() {
+        Boolean preChecks = env.getProperty("configuration.security.preChecks", Boolean.class, true);
+        if(!preChecks) {
+            return;
+        }
+        LogUtil.printMessage("========= [ EXECUTING PRE-CHECKS ] ================================");
+        LogUtil.printMessage("[ EDC Connection Test ] Testing connection with the EDC Consumer, this may take some seconds...");
+        try {
+            String bpnNumber = dataTransferService.checkEdcConsumerConnection();
+            String participantId = (String) vaultService.getLocalSecret("edc.participantId");
+            if (participantId.isEmpty()) {
+                throw new Exception("[" + this.getClass().getName() + ".onStartUp] ParticipantId configuration does not exists in Vault File!");
+            }
+            if (!participantId.equals(bpnNumber)) {
+                throw new Exception("[" + this.getClass().getName() + ".onStartUp] Incorrect BPN Number configuration, expected the same participant id as the EDC consumer connector!");
+            }
+            LogUtil.printMessage("[ EDC Connection Test ] The EDC consumer is available for receiving connections!");
+        } catch (Exception e) {
+            throw new IncompatibleConfigurationException(e.getMessage());
+        }
 
+    }
     @EventListener(ApplicationReadyEvent.class)
     public void onStartUp() {
+        LogUtil.printMessage("========= [ APPLICATION STARTED ] =================================");
         String serverStartUpMessage = "\n\n" +
                 "************************************************\n" +
                 buildProperties.getName()+"\n" +
-                "Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA\n" +
+                "Copyright (c) 2022, 2023: BASF SE, BMW AG, Henkel AG & Co. KGaA\n" +
                 "Copyright (c) 2022, 2023: Contributors to the CatenaX (ng) GitHub Organisation.\n" +
                 "Version: "+ buildProperties.getVersion()  + "\n\n" +
                  "\n\n-------------> [ SERVER STARTED ] <-------------\n" +
                 "Listening to requests...\n\n";
 
         LogUtil.printMessage(serverStartUpMessage);
-        LogUtil.printMessage("[ LOGGING STARTED ] <-----------------------------------------");
+        LogUtil.printMessage("========= [ LOGGING STARTED ] ================================");
         LogUtil.printMessage("Creating log file...");
+
         // Store the process manager in memory
        }
 

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/listeners/AppListener.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/listeners/AppListener.java
@@ -71,70 +71,77 @@ public class AppListener {
     Environment env;
     @Autowired
     DataTransferService dataTransferService;
+
     @EventListener(ApplicationStartedEvent.class)
     public void started() {
         Boolean preChecks = env.getProperty("configuration.security.check.enabled", Boolean.class, true);
-        if(!preChecks) {
+        if (!preChecks) {
             return;
         }
 
         Boolean bpnCheck = env.getProperty("configuration.security.check.bpn", Boolean.class, true);
         Boolean edcCheck = env.getProperty("configuration.security.check.edc", Boolean.class, true);
-        if(!bpnCheck && !edcCheck) {
+        if (!bpnCheck && !edcCheck) {
             return;
         }
-        try{
-        LogUtil.printMessage("========= [ EXECUTING PRE-CHECKS ] ================================");
-        LogUtil.printMessage("[ EDC Connection Test ] Testing connection with the EDC Consumer, this may take some seconds...");
-        String participantId = (String) vaultService.getLocalSecret("edc.participantId");
-        if (participantId.isEmpty()) {
-            throw new Exception("[" + this.getClass().getName() + ".onStartUp] ParticipantId configuration does not exists in Vault File!");
-        }
         try {
-            String bpnNumber = dataTransferService.checkEdcConsumerConnection();
-            if (!participantId.equals(bpnNumber)) {
-                throw new Exception("[" + this.getClass().getName() + ".onStartUp] Incorrect BPN Number configuration, expected the same participant id as the EDC consumer connector!");
+            LogUtil.printMessage("========= [ EXECUTING PRE-CHECKS ] ================================");
+            String participantId = (String) vaultService.getLocalSecret("edc.participantId");
+            if (participantId.isEmpty()) {
+                throw new Exception("[" + this.getClass().getName() + ".onStartUp] ParticipantId configuration does not exists in Vault File!");
             }
-            LogUtil.printMessage("[ EDC Connection Test ] The EDC consumer is available for receiving connections!");
-        } catch (Exception e) {
-            throw new IncompatibleConfigurationException(e.getMessage());
-        }
-        try {
-            LogUtil.printMessage("[ BPN Number Check ] Checking the token from the technical user...");
-            JwtToken token = authService.getToken();
-            if(token == null){
-                throw new Exception("[" + this.getClass().getName() + ".onStartUp] Not possible to get technical user credentials!");
+            if (edcCheck) {
+                try {
+                    LogUtil.printMessage("[ EDC Connection Test ] Testing connection with the EDC Consumer, this may take some seconds...");
+                    String bpnNumber = dataTransferService.checkEdcConsumerConnection();
+                    if (!participantId.equals(bpnNumber)) {
+                        throw new Exception("[" + this.getClass().getName() + ".onStartUp] Incorrect BPN Number configuration, expected the same participant id as the EDC consumer connector!");
+                    }
+                    LogUtil.printMessage("[ EDC Connection Test ] The EDC consumer is available for receiving connections!");
+                } catch (Exception e) {
+                    throw new IncompatibleConfigurationException(e.getMessage());
+                }
             }
-            Jwt jwtToken = httpUtil.parseToken(token.getAccessToken());
-            if(jwtToken == null){
-                throw new Exception("[" + this.getClass().getName() + ".onStartUp] The technical user JwtToken is empty!");
+            if (!bpnCheck) {
+                return;
             }
-            if(!jwtToken.getPayload().containsKey("bpn")){
-                throw new Exception("[" + this.getClass().getName() + ".onStartUp] The technical user JwtToken does not specify any BPN number!");
+            try {
+                LogUtil.printMessage("[ BPN Number Check ] Checking the token from the technical user...");
+                JwtToken token = authService.getToken();
+                if (token == null) {
+                    throw new Exception("[" + this.getClass().getName() + ".onStartUp] Not possible to get technical user credentials!");
+                }
+                Jwt jwtToken = httpUtil.parseToken(token.getAccessToken());
+                if (jwtToken == null) {
+                    throw new Exception("[" + this.getClass().getName() + ".onStartUp] The technical user JwtToken is empty!");
+                }
+                if (!jwtToken.getPayload().containsKey("bpn")) {
+                    throw new Exception("[" + this.getClass().getName() + ".onStartUp] The technical user JwtToken does not specify any BPN number!");
+                }
+                String techUserBpn = (String) jwtToken.getPayload().get("bpn");
+                if (!techUserBpn.equals(participantId)) {
+                    throw new Exception("[" + this.getClass().getName() + ".onStartUp] The technical user does not has the same BPN number as the EDC Consumer and the Backend! Access not allowed!");
+                }
+                LogUtil.printMessage("[ BPN Number Check ] Technical User BPN matches the EDC Consumer and the Backend participantId!");
+            } catch (Exception e) {
+                throw new IncompatibleConfigurationException(e.getMessage());
             }
-            String techUserBpn = (String) jwtToken.getPayload().get("bpn");
-            if(!techUserBpn.equals(participantId)){
-                throw new Exception("[" + this.getClass().getName() + ".onStartUp] The technical user does not has the same BPN number as the EDC Consumer and the Backend! Access not allowed!");
-            }
-            LogUtil.printMessage("[ BPN Number Check ] Technical User BPN matches the EDC Consumer and the Backend participantId!");
-        } catch (Exception e) {
-            throw new IncompatibleConfigurationException(e.getMessage());
-        }
         } catch (Exception e) {
             throw new IncompatibleConfigurationException(e.getMessage());
         }
 
     }
+
     @EventListener(ApplicationReadyEvent.class)
     public void onStartUp() {
         LogUtil.printMessage("========= [ APPLICATION STARTED ] =================================");
         String serverStartUpMessage = "\n\n" +
                 "************************************************\n" +
-                buildProperties.getName()+"\n" +
+                buildProperties.getName() + "\n" +
                 "Copyright (c) 2022, 2023: BASF SE, BMW AG, Henkel AG & Co. KGaA\n" +
                 "Copyright (c) 2022, 2023: Contributors to the CatenaX (ng) GitHub Organisation.\n" +
-                "Version: "+ buildProperties.getVersion()  + "\n\n" +
-                 "\n\n-------------> [ SERVER STARTED ] <-------------\n" +
+                "Version: " + buildProperties.getVersion() + "\n\n" +
+                "\n\n-------------> [ SERVER STARTED ] <-------------\n" +
                 "Listening to requests...\n\n";
 
         LogUtil.printMessage(serverStartUpMessage);
@@ -142,6 +149,6 @@ public class AppListener {
         LogUtil.printMessage("Creating log file...");
 
         // Store the process manager in memory
-       }
+    }
 
 }

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/services/AuthenticationService.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/services/AuthenticationService.java
@@ -29,6 +29,7 @@ import org.eclipse.tractusx.productpass.exceptions.ServiceException;
 import org.eclipse.tractusx.productpass.exceptions.ServiceInitializationException;
 import org.eclipse.tractusx.productpass.models.auth.JwtToken;
 import org.eclipse.tractusx.productpass.models.auth.UserInfo;
+import org.eclipse.tractusx.productpass.models.edc.Jwt;
 import org.eclipse.tractusx.productpass.models.service.BaseService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/services/DataTransferService.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/services/DataTransferService.java
@@ -119,7 +119,18 @@ public class DataTransferService extends BaseService {
 
         return missingVariables;
     }
-
+    public String checkEdcConsumerConnection() throws ControllerException {
+        try {
+            String edcConsumerDsp = this.edcEndpoint + CatenaXUtil.edcDataEndpoint;
+            Catalog catalog = this.getContractOfferCatalog(edcConsumerDsp, ""); // Get empty catalog
+            if (catalog == null || catalog.getParticipantId().isEmpty()) {
+                throw new ControllerException(this.getClass().getName()+".checkEdcConsumerConnection", "The catalog response is null or the participant id is not set!");
+            }
+            return catalog.getParticipantId();
+        }catch (Exception e) {
+            throw new ControllerException(this.getClass().getName()+".checkEdcConsumerConnection", e, "It was not possible to establish connection with the EDC consumer endpoint [" + this.edcEndpoint+"]");
+        }
+    }
     public Dataset getContractOfferByAssetId(String assetId, String providerUrl) throws ControllerException {
         /*
          *   This method receives the assetId and looks up for targets with the same name.
@@ -458,7 +469,6 @@ public class DataTransferService extends BaseService {
                     providerUrl,
                     querySpec
             );
-
             HttpHeaders headers = httpUtil.getHeaders();
             headers.add("Content-Type", "application/json");
             headers.add("X-Api-Key", this.apiKey);

--- a/consumer-backend/productpass/src/main/java/utils/CatenaXUtil.java
+++ b/consumer-backend/productpass/src/main/java/utils/CatenaXUtil.java
@@ -36,8 +36,8 @@ import java.util.regex.Pattern;
 
 public final class CatenaXUtil {
 
-    private final static String bpnNumberPattern = "BPN[LSA][A-Z0-9]{12}";
-    private final static String edcDataEndpoint = "/api/v1/dsp";
+    public final static String bpnNumberPattern = "BPN[LSA][A-Z0-9]{12}";
+    public final static String edcDataEndpoint = "/api/v1/dsp";
 
     public static Boolean containsBPN(String str){
         return str.matches(".*"+bpnNumberPattern+".*");

--- a/consumer-backend/productpass/src/main/java/utils/HttpUtil.java
+++ b/consumer-backend/productpass/src/main/java/utils/HttpUtil.java
@@ -184,7 +184,6 @@ public class HttpUtil {
 
             String header = CrypUtil.fromBase64Url(chunks[0]);
             String payload = CrypUtil.fromBase64Url(chunks[1]);
-            LogUtil.printMessage("token header: " + header + " payload: " + payload);
             jwt.setHeader((Map<String, Object>) jsonUtil.parseJson(header));
             jwt.setPayload((Map<String, Object>) jsonUtil.parseJson(payload));
             return jwt;

--- a/consumer-backend/productpass/src/main/resources/application.yml
+++ b/consumer-backend/productpass/src/main/resources/application.yml
@@ -53,6 +53,9 @@ configuration:
     transfer: '/transferprocesses'
     receiverEndpoint: 'https://materialpass.dev.demo.catena-x.net/endpoint'
 
+  security:
+    preChecks: true
+
   process:
     store: true
     dir: 'process'

--- a/consumer-backend/productpass/src/main/resources/application.yml
+++ b/consumer-backend/productpass/src/main/resources/application.yml
@@ -42,19 +42,23 @@ configuration:
   keycloak:
     realm: CX-Central
     resource: Cl13-CX-Battery
-    tokenUri: 'https://centralidp.dev.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token'
-    userInfoUri: 'https://centralidp.dev.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/userinfo'
+    tokenUri: 'https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token'
+    userInfoUri: 'https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/userinfo'
 
   edc:
-    endpoint: 'https://materialpass.dev.demo.catena-x.net/consumer'
+    endpoint: 'https://materialpass.int.demo.catena-x.net/consumer'
     management: '/management/v2'
     catalog: '/catalog/request'
     negotiation: '/contractnegotiations'
     transfer: '/transferprocesses'
-    receiverEndpoint: 'https://materialpass.dev.demo.catena-x.net/endpoint'
+    receiverEndpoint: 'https://materialpass.int.demo.catena-x.net/endpoint'
 
   security:
-    preChecks: true
+    check:
+      enabled: true
+      bpn: true
+      edc: true
+
 
   process:
     store: true
@@ -63,7 +67,7 @@ configuration:
     signKey: 'c55e3f35200f6afedbce37cefdaf40eadd15c92814edfdbc4d6ab0eacdcdd56dbcd5a2a34ca4b675084d33f9f479d7d79347795148aaf4443e1b47ab96b27e72'
 
   endpoints:
-    registryUrl: 'https://semantics.dev.demo.catena-x.net'
+    registryUrl: 'https://semantics.int.demo.catena-x.net'
 
   passport:
     dataTransfer:


### PR DESCRIPTION
**The changes are already reviewed in PR #129. Therefore, merging changes into new develop**

# Why we create this PR?
 
There is a data souverenighty requirement that states that we need to check the BPN number from EDC consumer and the Backend. 
 
# What we want to achieve with this PR?
 
We want to achieve that the backend is able to start just if:
    - The EDC Consumer Connector is accesible
    - The EDC BPN number is the same as the BPN configured in the Backend
    - The Backend Tech User is valid
    - The Backend Tech User BPN number contained in the token is the same as the EDC and the Backend. 
 
# What is new?

## Added
  - Added check on startup to check if the EDC Consumer Connector is accesible.
  - Added check on startup to check if the EDC Connector BPN is the same as the Backend BPN
  - Added check on startup to check if the Tech user configured is valid
  - Added check on startup to check if the Tech user configured has the same BPN number as the EDC consumer.

## PR Linked to:

| Tickets |
| :---:   |
| [cmp 591](www.jira.catena-x.net/browse/CMP-591) |