### PR TITLE
Feature/cmp 863/irs setup: prepare irs helm chart and initial postman collection

### DIFF
--- a/deployment/helm/edc-consumer/Chart.yaml
+++ b/deployment/helm/edc-consumer/Chart.yaml
@@ -42,3 +42,7 @@ dependencies:
     version: 12.1.6
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
+  - name: irs-helm
+    repository: https://eclipse-tractusx.github.io/item-relationship-service
+    version: 6.6.0
+    condition: irs-helm.enabled

--- a/deployment/helm/edc-consumer/values-int.yaml
+++ b/deployment/helm/edc-consumer/values-int.yaml
@@ -169,7 +169,7 @@ tractusx-connector:
 
   postgresql:
     username: <path:material-pass/data/int/edc/database#user>
-    password: <path:material-pass/data/int/edc/database#user>
+    password: <path:material-pass/data/int/edc/database#password>
 
   vault:
     hashicorp:
@@ -190,3 +190,70 @@ postgresql:
   auth:
     username: <path:material-pass/data/int/edc/database#user>
     password: <path:material-pass/data/int/edc/database#password>
+
+irs-helm:
+  enabled: true
+  bpn: <path:material-pass/data/int/edc/participant#bpnNumber>
+
+  nameOverride: "dpp-irs"
+  fullnameOverride: "dpp-irs"
+
+  # namespace: product-material-pass
+
+  irsUrl: "https://materialpass-irs.int.demo.catena-x.net"
+
+  ingress:
+    enabled: true
+    annotations:
+      ingressClassName: nginx
+      nginx.ingress.kubernetes.io/backend-protocol: HTTP
+      nginx.ingress.kubernetes.io/force-ssl-redirect: 'true'
+      nginx.ingress.kubernetes.io/ssl-passthrough: 'false'
+    hosts:
+      - host: "materialpass-irs.int.demo.catena-x.net"
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - hosts:
+          - "materialpass-irs.int.demo.catena-x.net"
+        secretName: tls-secret
+
+  digitalTwinRegistry:
+    type: decentral
+    url: https://materialpass.int.demo.catena-x.net/semantics/registry/api/v3.0
+    discoveryFinderUrl: https://semantics.int.demo.catena-x.net/discoveryfinder/api/administration/connectors/discovery/search
+  semanticshub:
+    url: https://semantics.int.demo.catena-x.net/hub/api/v1/models
+  bpdm:
+    url: https://partners-pool.int.demo.catena-x.net
+    bpnEndpoint: >-
+      {{- if .Values.bpdm.url }}
+      {{- tpl (.Values.bpdm.url | default "") . }}/api/catena/legal-entities/{partnerId}?idType={idType}
+      {{- end }}
+
+  minioUser: <path:material-pass/data/int/irs/minio#user>
+  minioPassword: <path:material-pass/data/int/irs/minio#password>
+  minioUrl: "http://{{ .Release.Name }}-minio:9000"
+
+  keycloak:
+    oauth2:
+      clientId: <path:material-pass/data/int/irs/keycloak/oauth2#clientId>
+      clientSecret: <path:material-pass/data/int/irs/keycloak/oauth2#clientSecret>
+      clientTokenUri: https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token
+      jwkSetUri: https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/certs
+
+  edc:
+    controlplane:
+      endpoint:
+        data: https://materialpass.int.demo.catena-x.net/consumer/management
+      apikey:
+        secret: <path:material-pass/data/int/edc/oauth#api.key>
+
+  minio:
+    nameOverride: "dpp-irs-minio"
+    fullnameOverride: "dpp-irs-minio"
+    serviceAccount:
+      create: false
+    rootUser: <path:material-pass/data/int/irs/minio#user>
+    rootPassword: <path:material-pass/data/int/irs/minio#password>

--- a/deployment/helm/edc-consumer/values.yaml
+++ b/deployment/helm/edc-consumer/values.yaml
@@ -519,11 +519,11 @@ tractusx-connector:
     jdbcUrl: "jdbc:postgresql://postgresql:5432/edc"
     fullnameOverride: "postgresql"
     username: <path:material-pass/data/dev/edc/database#user>
-    password: <path:material-pass/data/dev/edc/database#user>
+    password: <path:material-pass/data/dev/edc/database#password>
     auth:
       database: "edc"
       username: <path:material-pass/data/dev/edc/database#user>
-      password: <path:material-pass/data/dev/edc/database#user>
+      password: <path:material-pass/data/dev/edc/database#password>
 
   vault:
     fullnameOverride: "vault"
@@ -596,3 +596,6 @@ postgresql:
     database: "edc"
     username: <path:material-pass/data/dev/edc/database#user>
     password: <path:material-pass/data/dev/edc/database#password>
+
+irs-helm:
+  enabled: true

--- a/deployment/helm/irs/.helmignore
+++ b/deployment/helm/irs/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployment/helm/irs/Chart.yaml
+++ b/deployment/helm/irs/Chart.yaml
@@ -31,3 +31,11 @@ dependencies:
     repository: https://eclipse-tractusx.github.io/item-relationship-service
     version: 6.6.0
     condition: irs-helm.enabled
+  - name: tractusx-connector
+    repository: https://eclipse-tractusx.github.io/charts/dev
+    version: 0.5.0
+  - condition: postgresql.enabled
+    alias: edc-postgresql
+    name: postgresql
+    repository: https://charts.bitnami.com/bitnami
+    version: 12.1.6

--- a/deployment/helm/irs/Chart.yaml
+++ b/deployment/helm/irs/Chart.yaml
@@ -1,0 +1,33 @@
+#################################################################################
+# Catena-X - Product Passport Consumer Application
+#
+# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+apiVersion: v2
+name: irs
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: "3.3.4"
+dependencies:
+  - name: irs-helm
+    repository: https://eclipse-tractusx.github.io/item-relationship-service
+    version: 6.4.2
+    condition: irs-helm.enabled

--- a/deployment/helm/irs/Chart.yaml
+++ b/deployment/helm/irs/Chart.yaml
@@ -25,9 +25,9 @@ name: irs
 description: A Helm chart for Kubernetes
 type: application
 version: 0.1.0
-appVersion: "3.3.4"
+appVersion: "3.4.0"
 dependencies:
   - name: irs-helm
     repository: https://eclipse-tractusx.github.io/item-relationship-service
-    version: 6.4.2
+    version: 6.6.0
     condition: irs-helm.enabled

--- a/deployment/helm/irs/values-int.yaml
+++ b/deployment/helm/irs/values-int.yaml
@@ -83,7 +83,7 @@ irs-helm:
   edc:
     controlplane:
       endpoint:
-        data: https://materialpass.int.demo.catena-x.net/consumer/management
+        data: https://materialpass-irs.int.demo.catena-x.net/consumer/management
       apikey:
         secret: <path:material-pass/data/int/edc/oauth#api.key>
 
@@ -94,3 +94,164 @@ irs-helm:
       create: false
     rootUser: <path:material-pass/data/int/irs/minio#user>
     rootPassword: <path:material-pass/data/int/irs/minio#password>
+
+tractusx-connector:
+  enabled: true
+  participant:
+    id: "<path:material-pass/data/int/edc/participant#bpnNumber>"
+
+  controlplane:
+    enabled: true
+    endpoints:
+      # -- default api for health checks, should not be added to any ingress
+      default:
+        # -- port for incoming api calls
+        port: 8080
+        # -- path for incoming api calls
+        path: /consumer/api
+      # -- data management api, used by internal users, can be added to an ingress and must not be internet facing
+      management:
+        # -- port for incoming api calls
+        port: 8081
+        # -- path for incoming api calls
+        path: /consumer/management
+        # -- authentication key, must be attached to each 'X-Api-Key' request header
+        authKey: <path:material-pass/data/int/edc/oauth#api.key>
+      # -- control api, used for internal control calls. can be added to the internal ingress, but should probably not
+      control:
+        # -- port for incoming api calls
+        port: 8083
+        # -- path for incoming api calls
+        path: /consumer/control
+      # -- ids api, used for inter connector communication and must be internet facing
+      protocol:
+        # -- port for incoming api calls
+        port: 8084
+        # -- path for incoming api calls
+        path: /consumer/api/v1/dsp
+      # -- metrics api, used for application metrics, must not be internet facing
+      metrics:
+        # -- port for incoming api calls
+        port: 9090
+        # -- path for incoming api calls
+        path: /consumer/metrics
+      # -- observability api with unsecured access, must not be internet facing
+      observability:
+        # -- port for incoming API calls
+        port: 8085
+        # -- observability api, provides /health /readiness and /liveness endpoints
+        path: /consumer/observability
+        # -- allow or disallow insecure access, i.e. access without authentication
+        insecure: true
+
+    ssi:
+      miw:
+        url: "<path:material-pass/data/int/edc/ssi#miwUrl>"
+        authorityId: "<path:material-pass/data/int/edc/ssi#authorityId>"
+      oauth:
+        tokenurl: "https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+        client:
+          id: "<path:material-pass/data/int/edc/ssi#clientId>"
+          secretAlias: "int-client-secret"
+      endpoint:
+        audience: https://materialpass-irs.int.demo.catena-x.net/consumer
+
+    ## Ingress declaration to expose the network service.
+    ingresses:
+      ## Public / Internet facing Ingress
+      - enabled: true
+        # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
+        hostname: "materialpass-irs.int.demo.catena-x.net"
+       # -- Additional ingress annotations to add
+        annotations: {}
+        # -- EDC endpoints exposed by this ingress resource
+        endpoints:
+          - default
+          - management
+          - control
+          - protocol
+          - metrics
+          - observability
+        # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
+        className: "nginx"
+        # -- TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource
+        tls:
+          # -- Enables TLS on the ingress resource
+          enabled: true
+          # -- If present overwrites the default secret name
+          secretName: "tls-secret"
+  dataplane:
+    enabled: true
+    endpoints:
+      default:
+        port: 8080
+        path: /consumer/api
+      public:
+        port: 8081
+        path: /consumer/api/public
+      control:
+        port: 8083
+        path: /consumer/api/dataplane/control
+      proxy:
+        port: 8186
+        path: /consumer/proxy
+      observability:
+        # -- port for incoming API calls
+        port: 8085
+        # -- observability api, provides /health /readiness and /liveness endpoints
+        path: /consumer/observability
+        # -- allow or disallow insecure access, i.e. access without authentication
+        insecure: true
+      metrics:
+        port: 9090
+        path: /consumer/metrics
+  
+    ## Ingress declaration to expose the network service.
+    ingresses:
+      ## Public / Internet facing Ingress
+      - enabled: true
+        # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
+        hostname: "materialpass-irs.int.demo.catena-x.net"
+        # -- Additional ingress annotations to add
+        annotations: {}
+        # -- EDC endpoints exposed by this ingress resource
+        endpoints:
+          - public
+        # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
+        className: "nginx"
+        # -- TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource
+        tls:
+          # -- Enables TLS on the ingress resource
+          enabled: true
+          # -- If present overwrites the default secret name
+          secretName: "tls-secret"
+        ## Adds [cert-manager](https://cert-manager.io/docs/) annotations to the ingress resource
+        certManager:
+          # -- If preset enables certificate generation via cert-manager namespace scoped issuer
+          issuer: ""
+          # -- If preset enables certificate generation via cert-manager cluster-wide issuer
+          clusterIssuer: ""
+
+  postgresql:
+    username: <path:material-pass/data/int/edc/database#user>
+    password: <path:material-pass/data/int/edc/database#password>
+
+  vault:
+    hashicorp:
+      url: <path:material-pass/data/int/edc/vault#vault.hashicorp.url>
+      token: <path:material-pass/data/int/edc/vault#vault.hashicorp.token>
+      paths:
+        secret:  <path:material-pass/data/int/edc/vault#vault.hashicorp.api.secret.path>
+        health: /v1/sys/health
+    secretNames:
+      transferProxyTokenSignerPrivateKey: ids-daps_key
+      transferProxyTokenSignerPublicKey: ids-daps_crt
+      transferProxyTokenEncryptionAesKey: edc-encryption-key
+
+  # backendService:
+  #    httpProxyTokenReceiverUrl: "https://materialpass-irs.int.demo.catena-x.net/endpoint"
+
+postgresql:
+  auth:
+    username: <path:material-pass/data/int/edc/database#user>
+    password: <path:material-pass/data/int/edc/database#password>

--- a/deployment/helm/irs/values-int.yaml
+++ b/deployment/helm/irs/values-int.yaml
@@ -1,0 +1,96 @@
+#################################################################################
+# Catena-X - Product Passport Consumer Application
+#
+# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+### The fully configuration is available in https://github.com/eclipse-tractusx/item-relationship-service/tree/main/charts/irs-helm
+
+---
+
+irs-helm:
+  enabled: true
+  bpn: <path:material-pass/data/int/edc/participant#bpnNumber>
+
+  nameOverride: "dpp-irs"
+  fullnameOverride: "dpp-irs"
+
+  # namespace: product-material-pass
+
+  irsUrl: "https://materialpass-irs.int.demo.catena-x.net"
+
+  ingress:
+    enabled: true
+    annotations:
+      ingressClassName: nginx
+      nginx.ingress.kubernetes.io/backend-protocol: HTTP
+      nginx.ingress.kubernetes.io/force-ssl-redirect: 'true'
+      nginx.ingress.kubernetes.io/ssl-passthrough: 'false'
+    hosts:
+      - host: "materialpass-irs.int.demo.catena-x.net"
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - hosts:
+          - "materialpass-irs.int.demo.catena-x.net"
+        secretName: tls-secret
+
+  digitalTwinRegistry:
+    type: decentral
+    url: https://materialpass.int.demo.catena-x.net/semantics/registry/api/v3.0
+    discoveryFinderUrl: https://semantics.int.demo.catena-x.net/discoveryfinder/api/administration/connectors/discovery/search
+  semanticshub:
+    url: https://semantics.int.demo.catena-x.net/hub/api/v1/models
+  bpdm:
+    url: https://partners-pool.int.demo.catena-x.net
+    bpnEndpoint: >-
+      {{- if .Values.bpdm.url }}
+      {{- tpl (.Values.bpdm.url | default "") . }}/api/catena/legal-entities/{partnerId}?idType={idType}
+      {{- end }}
+
+  minioUser: <path:material-pass/data/int/irs/minio#user>
+  minioPassword: <path:material-pass/data/int/irs/minio#password>
+  minioUrl: "http://{{ .Release.Name }}-minio:9000"
+
+  keycloak:
+    oauth2:
+      clientId: <path:material-pass/data/int/irs/keycloak/oauth2#clientId>
+      clientSecret: <path:material-pass/data/int/irs/keycloak/oauth2#clientSecret>
+      clientTokenUri: https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token
+      jwkSetUri: https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/certs
+  # portal:
+  #   oauth2:
+  #     clientId:  # <portal-client-id>
+  #     clientSecret:  # <portal-client-secret>
+
+  edc:
+    controlplane:
+      endpoint:
+        data: https://materialpass.int.demo.catena-x.net/consumer/management
+      apikey:
+        secret: <path:material-pass/data/int/edc/oauth#api.key>
+
+  minio:
+    nameOverride: "dpp-irs-minio"
+    fullnameOverride: "dpp-irs-minio"
+    serviceAccount:
+      create: false
+    rootUser: <path:material-pass/data/int/irs/minio#user>
+    rootPassword: <path:material-pass/data/int/irs/minio#password>

--- a/deployment/helm/irs/values.yaml
+++ b/deployment/helm/irs/values.yaml
@@ -25,6 +25,572 @@
 ---
 
 irs-helm:
-  enabled: false
+  enabled: true
 
+tractusx-connector:
+  enabled: true
+  install:
+    daps: false
+    postgresql: false
+    vault: false
+  fullnameOverride: "irs-edc-consumer"
+  nameOverride: ""
+  # -- Existing image pull secret to use to [obtain the container image from private registries](https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry)
+  imagePullSecrets: []
+  customLabels: {}
 
+    
+  participant:
+    id: "<path:material-pass/data/dev/edc/participant#bpnNumber>"
+
+  controlplane:
+    enabled: true
+    image:
+      # -- Which derivate of the control plane to use. when left empty the deployment will select the correct image automatically
+      repository: "tractusx/edc-controlplane-postgresql-hashicorp-vault"
+      # -- [Kubernetes image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) to use
+      pullPolicy: IfNotPresent
+      # -- Overrides the image tag whose default is the chart appVersion
+      tag: "0.5.0"
+    initContainers: []
+    debug:
+      enabled: false
+      port: 1044
+      suspendOnStart: false
+    internationalDataSpaces:
+      id: TXDC
+      description: Tractus-X Eclipse IDS Data Space Connector
+      title: ""
+      maintainer: ""
+      curator: ""
+      catalogId: TXDC-Catalog
+    livenessProbe:
+      # -- Whether to enable kubernetes [liveness-probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+      enabled: true
+      # -- seconds to wait before performing the first liveness check
+      initialDelaySeconds: 30
+      # -- this fields specifies that kubernetes should perform a liveness check every 10 seconds
+      periodSeconds: 10
+      # -- number of seconds after which the probe times out
+      timeoutSeconds: 5
+      # -- when a probe fails kubernetes will try 6 times before giving up
+      failureThreshold: 6
+      # -- number of consecutive successes for the probe to be considered successful after having failed
+      successThreshold: 1
+    readinessProbe:
+      # -- Whether to enable kubernetes [readiness-probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+      enabled: true
+      # -- seconds to wait before performing the first readiness check
+      initialDelaySeconds: 30
+      # -- this fields specifies that kubernetes should perform a readiness check every 10 seconds
+      periodSeconds: 10
+      # -- number of seconds after which the probe times out
+      timeoutSeconds: 5
+      # -- when a probe fails kubernetes will try 6 times before giving up
+      failureThreshold: 6
+      # -- number of consecutive successes for the probe to be considered successful after having failed
+      successThreshold: 1
+    # -- endpoints of the control plane
+    endpoints:
+      # -- default api for health checks, should not be added to any ingress
+      default:
+        # -- port for incoming api calls
+        port: 8080
+        # -- path for incoming api calls
+        path: /consumer/api
+      # -- data management api, used by internal users, can be added to an ingress and must not be internet facing
+      management:
+        # -- port for incoming api calls
+        port: 8081
+        # -- path for incoming api calls
+        path: /consumer/management
+        # -- authentication key, must be attached to each 'X-Api-Key' request header
+        authKey: <path:material-pass/data/dev/edc/oauth#api.key>
+      # -- control api, used for internal control calls. can be added to the internal ingress, but should probably not
+      control:
+        # -- port for incoming api calls
+        port: 8083
+        # -- path for incoming api calls
+        path: /consumer/control
+      # -- ids api, used for inter connector communication and must be internet facing
+      protocol:
+        # -- port for incoming api calls
+        port: 8084
+        # -- path for incoming api calls
+        path: /consumer/api/v1/dsp
+      # -- metrics api, used for application metrics, must not be internet facing
+      metrics:
+        # -- port for incoming api calls
+        port: 9090
+        # -- path for incoming api calls
+        path: /consumer/metrics
+      # -- observability api with unsecured access, must not be internet facing
+      observability:
+        # -- port for incoming API calls
+        port: 8085
+        # -- observability api, provides /health /readiness and /liveness endpoints
+        path: /consumer/observability
+        # -- allow or disallow insecure access, i.e. access without authentication
+        insecure: true
+    businessPartnerValidation:
+      log:
+        agreementValidation: true
+          # SSI configuration
+    ssi:
+      miw:
+        url: "<path:material-pass/data/dev/edc/ssi#miwUrl>"
+        authorityId: "<path:material-pass/data/dev/edc/ssi#authorityId>"
+      oauth:
+        tokenurl: "https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+        client:
+          id: "<path:material-pass/data/dev/edc/ssi#clientId>"
+          secretAlias: "dev-client-secret"
+      endpoint:
+        audience: https://materialpass.dev.demo.catena-x.net/consumer
+        
+    service:
+      # -- [Service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to expose the running application on a set of Pods as a network service.
+      type: ClusterIP
+      annotations: {}
+    # -- additional labels for the pod
+    podLabels: {}
+    # -- additional annotations for the pod
+    podAnnotations: {}
+    # -- The [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) defines privilege and access control settings for a Pod within the deployment
+    podSecurityContext:
+      seccompProfile:
+        # -- Restrict a Container's Syscalls with seccomp
+        type: RuntimeDefault
+      # -- Runs all processes within a pod with a special uid
+      runAsUser: 10001
+      # -- Processes within a pod will belong to this guid
+      runAsGroup: 10001
+      # -- The owner for volumes and any files created within volumes will belong to this guid
+      fsGroup: 10001
+    # The [container security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) defines privilege and access control settings for a Container within a pod
+    securityContext:
+      capabilities:
+        # -- Specifies which capabilities to drop to reduce syscall attack surface
+        drop:
+          - ALL
+        # -- Specifies which capabilities to add to issue specialized syscalls
+        add: []
+      # -- Whether the root filesystem is mounted in read-only mode
+      readOnlyRootFilesystem: true
+      # -- Controls [Privilege Escalation](https://kubernetes.io/docs/concepts/security/pod-security-policy/#privilege-escalation) enabling setuid binaries changing the effective user ID
+      allowPrivilegeEscalation: false
+      # -- Requires the container to run without root privileges
+      runAsNonRoot: true
+      # -- The container's process will run with the specified uid
+      runAsUser: 10001
+    # Extra environment variables that will be pass onto deployment pods
+    env: {}
+    #  ENV_NAME: value
+
+    # "valueFrom" environment variable references that will be added to deployment pods. Name is templated.
+    # ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvarsource-v1-core
+    envValueFrom: {}
+    #  ENV_NAME:
+    #    configMapKeyRef:
+    #      name: configmap-name
+    #      key: value_key
+    #    secretKeyRef:
+    #      name: secret-name
+    #      key: value_key
+
+    # [Kubernetes Secret Resource](https://kubernetes.io/docs/concepts/configuration/secret/) names to load environment variables from
+    envSecretNames: []
+    #  - first-secret
+    #  - second-secret
+
+    # [Kubernetes ConfigMap Resource](https://kubernetes.io/docs/concepts/configuration/configmap/) names to load environment variables from
+    envConfigMapNames: []
+    #  - first-config-map
+    #  - second-config-map
+
+    ## Ingress declaration to expose the network service.
+    ingresses:
+      ## Public / Internet facing Ingress
+      - enabled: true
+        # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
+        hostname: "materialpass-irs.dev.demo.catena-x.net"
+        # -- Additional ingress annotations to add
+        annotations: {}
+        # -- EDC endpoints exposed by this ingress resource
+        endpoints:
+          - default
+          - management
+          - control
+          - protocol
+          - metrics
+          - observability
+        # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
+        className: "nginx"
+        # -- TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource
+        tls:
+          # -- Enables TLS on the ingress resource
+          enabled: true
+          # -- If present overwrites the default secret name
+          secretName: "tls-secret"
+        ## Adds [cert-manager](https://cert-manager.io/docs/) annotations to the ingress resource
+        certManager:
+          # -- If preset enables certificate generation via cert-manager namespace scoped issuer
+          issuer: ""
+          # -- If preset enables certificate generation via cert-manager cluster-wide issuer
+          clusterIssuer: ""
+      ## Private / Intranet facing Ingress
+      - enabled: false
+        # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
+        hostname: "edc-control.intranet"
+        # -- Additional ingress annotations to add
+        annotations: {}
+        # -- EDC endpoints exposed by this ingress resource
+        endpoints:
+          - management
+          - control
+        # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
+        className: "nginx"
+        # -- TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource
+        tls:
+          # -- Enables TLS on the ingress resource
+          enabled: true
+          # -- If present overwrites the default secret name
+          secretName: "tls-secret"
+        ## Adds [cert-manager](https://cert-manager.io/docs/) annotations to the ingress resource
+        certManager:
+          # -- If preset enables certificate generation via cert-manager namespace scoped issuer
+          issuer: ""
+          # -- If preset enables certificate generation via cert-manager cluster-wide issuer
+          clusterIssuer: ""
+    # -- declare where to mount [volumes](https://kubernetes.io/docs/concepts/storage/volumes/) into the container
+    volumeMounts: []
+    # -- [volume](https://kubernetes.io/docs/concepts/storage/volumes/) directories
+    volumes: []
+    # -- [resource management](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the container
+    resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    replicaCount: 1
+    autoscaling:
+      # -- Enables [horizontal pod autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
+      enabled: false
+      # -- Minimal replicas if resource consumption falls below resource threshholds
+      minReplicas: 1
+      # -- Maximum replicas if resource consumption exceeds resource threshholds
+      maxReplicas: 100
+      # -- targetAverageUtilization of cpu provided to a pod
+      targetCPUUtilizationPercentage: 80
+      # -- targetAverageUtilization of memory provided to a pod
+      targetMemoryUtilizationPercentage: 80
+    # -- configuration of the [Open Telemetry Agent](https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/) to collect and expose metrics
+    opentelemetry: |-
+      otel.javaagent.enabled=false
+      otel.javaagent.debug=false
+    # -- configuration of the [Java Util Logging Facade](https://docs.oracle.com/javase/7/docs/technotes/guides/logging/overview.html)
+    logging: |-
+      .level=INFO
+      org.eclipse.edc.level=ALL
+      handlers=java.util.logging.ConsoleHandler
+      java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+      java.util.logging.ConsoleHandler.level=ALL
+      java.util.logging.SimpleFormatter.format=[%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS] [%4$-7s] %5$s%6$s%n
+    # [node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to constrain pods to nodes
+    nodeSelector: {}
+    # [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) to configure preferred nodes
+    tolerations: []
+    # [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) to configure which nodes the pods can be scheduled on
+    affinity: {}
+    url:
+      # -- Explicitly declared url for reaching the ids api (e.g. if ingresses not used)
+      ids: ""
+  dataplane:
+    enabled: true
+    image:
+      # -- Which derivate of the data plane to use. when left empty the deployment will select the correct image automatically
+      repository: "tractusx/edc-dataplane-hashicorp-vault"
+      # -- [Kubernetes image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) to use
+      pullPolicy: IfNotPresent
+      # -- Overrides the image tag whose default is the chart appVersion
+      tag: "0.5.0"
+    initContainers: []
+    debug:
+      enabled: false
+      port: 1044
+      suspendOnStart: false
+    livenessProbe:
+      # -- Whether to enable kubernetes [liveness-probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+      enabled: true
+      # -- seconds to wait before performing the first liveness check
+      initialDelaySeconds: 30
+      # -- this fields specifies that kubernetes should perform a liveness check every 10 seconds
+      periodSeconds: 10
+      # -- number of seconds after which the probe times out
+      timeoutSeconds: 5
+      # -- when a probe fails kubernetes will try 6 times before giving up
+      failureThreshold: 6
+      # -- number of consecutive successes for the probe to be considered successful after having failed
+      successThreshold: 1
+    readinessProbe:
+      # -- Whether to enable kubernetes [readiness-probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+      enabled: true
+      # -- seconds to wait before performing the first readiness check
+      initialDelaySeconds: 30
+      # -- this fields specifies that kubernetes should perform a liveness check every 10 seconds
+      periodSeconds: 10
+      # -- number of seconds after which the probe times out
+      timeoutSeconds: 5
+      # -- when a probe fails kubernetes will try 6 times before giving up
+      failureThreshold: 6
+      # -- number of consecutive successes for the probe to be considered successful after having failed
+      successThreshold: 1
+    service:
+      # -- [Service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to expose the running application on a set of Pods as a network service.
+      type: ClusterIP
+      port: 80
+    endpoints:
+      default:
+        port: 8080
+        path: /consumer/api
+      public:
+        port: 8081
+        path: /consumer/api/public
+      control:
+        port: 8083
+        path: /consumer/api/dataplane/control
+      proxy:
+        port: 8186
+        path: /consumer/proxy
+      observability:
+        # -- port for incoming API calls
+        port: 8085
+        # -- observability api, provides /health /readiness and /liveness endpoints
+        path: /consumer/observability
+        # -- allow or disallow insecure access, i.e. access without authentication
+        insecure: true
+      metrics:
+        port: 9090
+        path: /consumer/metrics
+    aws:
+      endpointOverride: ""
+      accessKeyId: ""
+      secretAccessKey: ""
+    # -- additional labels for the pod
+    podLabels: {}
+    # -- additional annotations for the pod
+    podAnnotations: {}
+    # -- The [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) defines privilege and access control settings for a Pod within the deployment
+    podSecurityContext:
+      seccompProfile:
+        # -- Restrict a Container's Syscalls with seccomp
+        type: RuntimeDefault
+      # -- Runs all processes within a pod with a special uid
+      runAsUser: 10001
+      # -- Processes within a pod will belong to this guid
+      runAsGroup: 10001
+      # -- The owner for volumes and any files created within volumes will belong to this guid
+      fsGroup: 10001
+    # The [container security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) defines privilege and access control settings for a Container within a pod
+    securityContext:
+      capabilities:
+        # -- Specifies which capabilities to drop to reduce syscall attack surface
+        drop:
+          - ALL
+        # -- Specifies which capabilities to add to issue specialized syscalls
+        add: []
+      # -- Whether the root filesystem is mounted in read-only mode
+      readOnlyRootFilesystem: true
+      # -- Controls [Privilege Escalation](https://kubernetes.io/docs/concepts/security/pod-security-policy/#privilege-escalation) enabling setuid binaries changing the effective user ID
+      allowPrivilegeEscalation: false
+      # -- Requires the container to run without root privileges
+      runAsNonRoot: true
+      # -- The container's process will run with the specified uid
+      runAsUser: 10001
+    # Extra environment variables that will be pass onto deployment pods
+    env: {}
+    #  ENV_NAME: value
+
+    # "valueFrom" environment variable references that will be added to deployment pods. Name is templated.
+    # ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvarsource-v1-core
+    envValueFrom: {}
+    #  ENV_NAME:
+    #    configMapKeyRef:
+    #      name: configmap-name
+    #      key: value_key
+    #    secretKeyRef:
+    #      name: secret-name
+    #      key: value_key
+
+    # [Kubernetes Secret Resource](https://kubernetes.io/docs/concepts/configuration/secret/) names to load environment variables from
+    envSecretNames: []
+    #  - first-secret
+    #  - second-secret
+
+    # [Kubernetes ConfigMap Resource](https://kubernetes.io/docs/concepts/configuration/configmap/) names to load environment variables from
+    envConfigMapNames: []
+    #  - first-config-map
+    #  - second-config-map
+
+    ## Ingress declaration to expose the network service.
+    ingresses:
+      ## Public / Internet facing Ingress
+      - enabled: true
+        # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
+        hostname: "materialpass-irs.dev.demo.catena-x.net"
+        # -- Additional ingress annotations to add
+        annotations: {}
+        # -- EDC endpoints exposed by this ingress resource
+        endpoints:
+          - public
+        # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
+        className: "nginx"
+        # -- TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource
+        tls:
+          # -- Enables TLS on the ingress resource
+          enabled: true
+          # -- If present overwrites the default secret name
+          secretName: "tls-secret"
+        ## Adds [cert-manager](https://cert-manager.io/docs/) annotations to the ingress resource
+        certManager:
+          # -- If preset enables certificate generation via cert-manager namespace scoped issuer
+          issuer: ""
+          # -- If preset enables certificate generation via cert-manager cluster-wide issuer
+          clusterIssuer: ""
+    # -- declare where to mount [volumes](https://kubernetes.io/docs/concepts/storage/volumes/) into the container
+    volumeMounts: []
+    # -- [volume](https://kubernetes.io/docs/concepts/storage/volumes/) directories
+    volumes: []
+    # -- [resource management](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the container
+    resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    replicaCount: 1
+    autoscaling:
+      # -- Enables [horizontal pod autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
+      enabled: false
+      # -- Minimal replicas if resource consumption falls below resource threshholds
+      minReplicas: 1
+      # -- Maximum replicas if resource consumption exceeds resource threshholds
+      maxReplicas: 100
+      # -- targetAverageUtilization of cpu provided to a pod
+      targetCPUUtilizationPercentage: 80
+      # -- targetAverageUtilization of memory provided to a pod
+      targetMemoryUtilizationPercentage: 80
+    # -- configuration of the [Open Telemetry Agent](https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/) to collect and expose metrics
+    opentelemetry: |-
+      otel.javaagent.enabled=false
+      otel.javaagent.debug=false
+    # -- configuration of the [Java Util Logging Facade](https://docs.oracle.com/javase/7/docs/technotes/guides/logging/overview.html)
+    logging: |-
+      .level=INFO
+      org.eclipse.edc.level=ALL
+      handlers=java.util.logging.ConsoleHandler
+      java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+      java.util.logging.ConsoleHandler.level=ALL
+      java.util.logging.SimpleFormatter.format=[%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS] [%4$-7s] %5$s%6$s%n
+    # [node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to constrain pods to nodes
+    nodeSelector: {}
+    # [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) to configure preferred nodes
+    tolerations: []
+    # [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) to configure which nodes the pods can be scheduled on
+    affinity: {}
+    url:
+      # -- Explicitly declared url for reaching the public api (e.g. if ingresses not used)
+      public: ""
+
+  postgresql:
+    jdbcUrl: "jdbc:postgresql://postgresql:5432/edc"
+    fullnameOverride: "postgresql"
+    username: <path:material-pass/data/dev/edc/database#user>
+    password: <path:material-pass/data/dev/edc/database#password>
+    auth:
+      database: "edc"
+      username: <path:material-pass/data/dev/edc/database#user>
+      password: <path:material-pass/data/dev/edc/database#password>
+
+  vault:
+    fullnameOverride: "vault"
+    injector:
+      enabled: false
+    server:
+      dev:
+        enabled: true
+        devRootToken: "root"
+      # Must be the same certificate that is configured in section 'daps'
+      postStart:    # must be set externally!
+    hashicorp:
+      url: <path:material-pass/data/dev/edc/vault#vault.hashicorp.url>
+      token: <path:material-pass/data/dev/edc/vault#vault.hashicorp.token>
+      timeout: 30
+      healthCheck:
+        enabled: true
+        standbyOk: true
+      paths:
+        secret:  <path:material-pass/data/dev/edc/vault#vault.hashicorp.api.secret.path>
+        health: /v1/sys/health
+    secretNames:
+      transferProxyTokenSignerPrivateKey: daps-key-dev
+      transferProxyTokenSignerPublicKey: daps-crt-dev
+      transferProxyTokenEncryptionAesKey: edc-encryption-key
+
+  backendService:
+    httpProxyTokenReceiverUrl: "https://materialpass.dev.demo.catena-x.net/endpoint"
+
+  networkPolicy:
+    # -- If `true` network policy will be created to restrict access to control- and dataplane
+    enabled: false
+    # -- Configuration of the controlplane component
+    controlplane:
+      # -- Specify from rule network policy for cp (defaults to all namespaces)
+      from:
+      - namespaceSelector: {}
+    # -- Configuration of the dataplane component
+    dataplane:
+      # -- Specify from rule network policy for dp (defaults to all namespaces)
+      from:
+      - namespaceSelector: {}
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+    # -- Existing image pull secret bound to the service account to use to [obtain the container image from private registries](https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry)
+    imagePullSecrets: []
+
+  # -- Configurations for Helm tests
+  tests:
+    # -- Configure the hook-delete-policy for Helm tests
+    hookDeletePolicy: before-hook-creation,hook-succeeded
+
+postgresql:
+  jdbcUrl: "jdbc:postgresql://postgresql:5432/edc"
+  fullnameOverride: "postgresql"
+  primary:
+    persistence:
+      enabled: true
+  readReplicas:
+    persistence:
+      enabled: true
+  auth:
+    database: "edc"
+    username: <path:material-pass/data/dev/edc/database#user>
+    password: <path:material-pass/data/dev/edc/database#password>

--- a/deployment/helm/irs/values.yaml
+++ b/deployment/helm/irs/values.yaml
@@ -1,0 +1,30 @@
+#################################################################################
+# Catena-X - Product Passport Consumer Application
+#
+# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+### The fully configuration is available in https://github.com/eclipse-tractusx/item-relationship-service/tree/main/charts/irs-helm
+
+---
+
+irs-helm:
+  enabled: false
+
+

--- a/postman/IRS/DPP-IRS.postman_collection.json
+++ b/postman/IRS/DPP-IRS.postman_collection.json
@@ -1,0 +1,372 @@
+{
+	"info": {
+		"_postman_id": "8fbfb90f-ff83-4343-a917-e65bb2ee468c",
+		"name": "DPP-IRS",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Policy Store",
+			"item": [
+				{
+					"name": "Get all Policies",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{IrsServer}}/irs/policies",
+							"host": [
+								"{{IrsServer}}"
+							],
+							"path": [
+								"irs",
+								"policies"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Register Policy",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n\t\"policyId\": \"R2_Traceability\",\r\n\t\"validUntil\": \"2026-08-01T00:00:00Z\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{IrsServer}}/irs/policies",
+							"host": [
+								"{{IrsServer}}"
+							],
+							"path": [
+								"irs",
+								"policies"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete Policy",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{IrsServer}}/irs/policies/{{policyId}}",
+							"host": [
+								"{{IrsServer}}"
+							],
+							"path": [
+								"irs",
+								"policies",
+								"{{policyId}}"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Digital Twin Registry",
+			"item": [
+				{
+					"name": "Get shell descriptors",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{registryUrl}}/shell-descriptors",
+							"host": [
+								"{{registryUrl}}"
+							],
+							"path": [
+								"shell-descriptors"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get shell by Id Copy",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{registryUrl}}/shell-descriptors/{{digitalTwinId}}",
+							"host": [
+								"{{registryUrl}}"
+							],
+							"path": [
+								"shell-descriptors",
+								"{{digitalTwinId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete Shell",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{registryUrl}}/shell-descriptors/{{digitalTwinId}}",
+							"host": [
+								"{{registryUrl}}"
+							],
+							"path": [
+								"shell-descriptors",
+								"{{digitalTwinId}}"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "IRS",
+			"item": [
+				{
+					"name": "1. Register Job",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"const jsonResponse = pm.response.json();\r",
+									"pm.collectionVariables.set(\"jobId\", jsonResponse.id);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"aspects\": [\r\n    \"BatteryPass\"\r\n  ],\r\n  \"bomLifecycle\": \"asBuilt\",\r\n  \"callbackUrl\": \"https://hostname.com/callback?id={id}&state={state}\",\r\n  \"collectAspects\": true,\r\n  \"depth\": 100,\r\n  \"direction\": \"downward\",\r\n  \"key\": {\r\n    \"bpn\": \"<some-bpn>\",\r\n    \"globalAssetId\": \"urn:uuid:1b17682e-5e2a-4913-aa1b-7d59a072a3cb\"\r\n  },\r\n  \"lookupBPNs\": true\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{irsServer}}/irs/jobs",
+							"host": [
+								"{{irsServer}}"
+							],
+							"path": [
+								"irs",
+								"jobs"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "2. Get specific Job",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{irsServer}}/irs/jobs/{{jobId}}",
+							"host": [
+								"{{irsServer}}"
+							],
+							"path": [
+								"irs",
+								"jobs",
+								"{{jobId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "3. Get Jobs",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{irsServer}}/irs/jobs?page=0&size=20",
+							"host": [
+								"{{irsServer}}"
+							],
+							"path": [
+								"irs",
+								"jobs"
+							],
+							"query": [
+								{
+									"key": "page",
+									"value": "0"
+								},
+								{
+									"key": "size",
+									"value": "20"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get all available Aspect models",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{irsServer}}/irs/aspectmodels",
+							"host": [
+								"{{irsServer}}"
+							],
+							"path": [
+								"irs",
+								"aspectmodels"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	],
+	"auth": {
+		"type": "oauth2",
+		"oauth2": [
+			{
+				"key": "accessTokenUrl",
+				"value": "https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token",
+				"type": "string"
+			},
+			{
+				"key": "scope",
+				"value": "openid profile email",
+				"type": "string"
+			},
+			{
+				"key": "clientSecret",
+				"value": "{{clientSecret}}",
+				"type": "string"
+			},
+			{
+				"key": "clientId",
+				"value": "{{clientId}}",
+				"type": "string"
+			},
+			{
+				"key": "challengeAlgorithm",
+				"value": "S256",
+				"type": "string"
+			},
+			{
+				"key": "username",
+				"value": "company 2 user",
+				"type": "string"
+			},
+			{
+				"key": "redirect_uri",
+				"value": "https://materialpass.int.demo.catena-x.net",
+				"type": "string"
+			},
+			{
+				"key": "password",
+				"value": "changeme",
+				"type": "string"
+			},
+			{
+				"key": "grant_type",
+				"value": "client_credentials",
+				"type": "string"
+			},
+			{
+				"key": "authUrl",
+				"value": "https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/auth",
+				"type": "string"
+			},
+			{
+				"key": "addTokenTo",
+				"value": "header",
+				"type": "string"
+			},
+			{
+				"key": "client_authentication",
+				"value": "header",
+				"type": "string"
+			}
+		]
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "digitalTwinId",
+			"value": "",
+			"type": "default"
+		},
+		{
+			"key": "clientId",
+			"value": "",
+			"type": "default"
+		},
+		{
+			"key": "clientSecret",
+			"value": "",
+			"type": "default"
+		},
+		{
+			"key": "irsServer",
+			"value": "",
+			"type": "default"
+		},
+		{
+			"key": "jobId",
+			"value": "",
+			"type": "default"
+		},
+		{
+			"key": "registryUrl",
+			"value": "",
+			"type": "default"
+		},
+		{
+			"key": "IrsServer",
+			"value": "",
+			"type": "default"
+		},
+		{
+			"key": "policyId",
+			"value": "",
+			"type": "default"
+		}
+	]
+}


### PR DESCRIPTION
# Why we create this PR?
 
This PR contains the following changes:

- Deploy full IRS (all components) locally as well as on DEV environment accessible at accessible at https://materialpass-irs.dev.demo.catena-x.net
- Setup IRS API component on INT environment (accessible through postman agent https://materialpass-irs.int.demo.catena-x.net)
- Prepared initial postman collection to test irs apis

# What we want to achieve with this PR?
 
To setup the IRS component in order to drill down Battery/DPP components
 
# What is new?
 
## Added
- Added IRS-API deployment
- Added IRS postman collection

| Tickets |
| :---:   |
| [cmp-863](https://jira.catena-x.net/browse/CMP-863) |