### PR TITLE
Feature/cmp 881/registry lookup: update lookup endpoint to the dDTR

### DIFF
--- a/charts/digital-product-pass/values-int.yaml
+++ b/charts/digital-product-pass/values-int.yaml
@@ -131,7 +131,7 @@ backend:
           endpointInterface: 'SUBMODEL-3.0'
           internalDtr: "https://materialpass.int.demo.catena-x.net/BPNL000000000000" # -- If there is an internal DTR available it can be referenced here and will be injected in the list of DTRs
           decentralApis:
-            search: "/lookup/shells/query"
+            search: "/lookup/shells"
             digitalTwin: "/shell-descriptors"
             subModel: "/submodel-descriptors"
           timeouts:

--- a/charts/digital-product-pass/values.yaml
+++ b/charts/digital-product-pass/values.yaml
@@ -157,7 +157,7 @@ backend:
           internalDtr: "" # -- ff there is an internal DTR available it can be referenced here and will be injected in the list of DTRs
           # -- decentral digital twin apis
           decentralApis:
-            search: "/lookup/shells/query"
+            search: "/lookup/shells"
             digitalTwin: "/shell-descriptors"
             subModel: "/submodel-descriptors"
           # -- timeouts for the digital twin registry async negotiation

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/models/dtregistry/DigitalTwin3.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/models/dtregistry/DigitalTwin3.java
@@ -23,18 +23,26 @@
 
 package org.eclipse.tractusx.productpass.models.dtregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.ArrayList;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class DigitalTwin3 {
     @JsonProperty("description")
     ArrayList<JsonNode> description;
     @JsonProperty("idShort")
     String idShort;
+
+    @JsonProperty("assetKind")
+    String assetKind;
+
+    @JsonProperty("assetType")
+    String assetType;
 
     @JsonProperty("globalAssetId")
     String globalAssetId;
@@ -72,6 +80,18 @@ public class DigitalTwin3 {
     public DigitalTwin3(ArrayList<JsonNode> description, String idShort, String globalAssetId, Object displayName, String identification, ArrayList<JsonNode> specificAssetIds, ArrayList<SubModel3> submodelDescriptors) {
         this.description = description;
         this.idShort = idShort;
+        this.globalAssetId = globalAssetId;
+        this.displayName = displayName;
+        this.identification = identification;
+        this.specificAssetIds = specificAssetIds;
+        this.submodelDescriptors = submodelDescriptors;
+    }
+
+    public DigitalTwin3(ArrayList<JsonNode> description, String idShort, String assetKind, String assetType, String globalAssetId, Object displayName, String identification, ArrayList<JsonNode> specificAssetIds, ArrayList<SubModel3> submodelDescriptors) {
+        this.description = description;
+        this.idShort = idShort;
+        this.assetKind = assetKind;
+        this.assetType = assetType;
         this.globalAssetId = globalAssetId;
         this.displayName = displayName;
         this.identification = identification;
@@ -135,5 +155,20 @@ public class DigitalTwin3 {
     public void setGlobalAssetId(String globalAssetId) {
         this.globalAssetId = globalAssetId;
     }
-}
 
+    public String getAssetKind() {
+        return assetKind;
+    }
+
+    public void setAssetKind(String assetKind) {
+        this.assetKind = assetKind;
+    }
+
+    public String getAssetType() {
+        return assetType;
+    }
+
+    public void setAssetType(String assetType) {
+        this.assetType = assetType;
+    }
+}

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/models/dtregistry/EndPoint3.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/models/dtregistry/EndPoint3.java
@@ -23,6 +23,7 @@
 
 package org.eclipse.tractusx.productpass.models.dtregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Splitter;
@@ -31,6 +32,7 @@ import utils.LogUtil;
 import java.util.List;
 import java.util.Map;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class EndPoint3 {
     @JsonProperty("interface")

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/models/dtregistry/SubModel3.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/models/dtregistry/SubModel3.java
@@ -23,16 +23,24 @@
 
 package org.eclipse.tractusx.productpass.models.dtregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.ArrayList;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SubModel3 {
     @JsonProperty("description")
     ArrayList<JsonNode> description;
     @JsonProperty("idShort")
     String idShort;
+
+    @JsonProperty("supplementalSemanticId")
+    Object supplementalSemanticId;
+
     @JsonProperty("id")
     String identification;
     @JsonProperty("semanticId")
@@ -50,6 +58,15 @@ public class SubModel3 {
     }
 
     public SubModel3() {
+    }
+
+    public SubModel3(ArrayList<JsonNode> description, String idShort, Object supplementalSemanticId, String identification, JsonNode semanticId, ArrayList<EndPoint3> endpoints) {
+        this.description = description;
+        this.idShort = idShort;
+        this.supplementalSemanticId = supplementalSemanticId;
+        this.identification = identification;
+        this.semanticId = semanticId;
+        this.endpoints = endpoints;
     }
 
     public ArrayList<JsonNode> getDescription() {
@@ -90,5 +107,13 @@ public class SubModel3 {
 
     public void setEndpoints(ArrayList<EndPoint3> endpoints) {
         this.endpoints = endpoints;
+    }
+
+    public Object getSupplementalSemanticId() {
+        return supplementalSemanticId;
+    }
+
+    public void setSupplementalSemanticId(Object supplementalSemanticId) {
+        this.supplementalSemanticId = supplementalSemanticId;
     }
 }

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/services/AasService.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/services/AasService.java
@@ -100,7 +100,7 @@ public class AasService extends BaseService {
         Object decentralApis = dtrConfig.getDecentralApis();
         if (decentralApis == null) { // If the configuration is null use the default variables
             decentralApis = Map.of(
-                    "search", "/lookup/shells/query",
+                    "search", "/lookup/shells",
                     "digitalTwin", "/shell-descriptors",
                     "subModel", "/submodel-descriptors"
             );
@@ -519,22 +519,21 @@ public class AasService extends BaseService {
             ResponseEntity<?> response = null;
             if (!this.central && registryUrl != null && edr != null) {
                 // Set request body as post if the central query is disabled
-                Object body = Map.of(
-                        "query", Map.of(
-                                "assetIds", List.of(
-                                        Map.of(
-                                                "name", assetType,
-                                                "value", assetId
-                                        )
-                                )
-                        )
+                // Query as GET if the central query is enabled
+                Map<String, ?> assetIds = Map.of(
+                        "name", assetType,
+                        "value", assetId
                 );
+
+                String jsonString = jsonUtil.toJson(assetIds, false);
                 HttpHeaders headers = this.getTokenHeader(edr);
-                response = httpUtil.doPost(url, ArrayList.class, headers, httpUtil.getParams(), body, false, false);
+                params.put("assetIds", jsonString);
+                response = httpUtil.doGet(url, ArrayList.class, headers, params, true, false);
+
             } else {
                 // Query as GET if the central query is enabled
                 Map<String, ?> assetIds = Map.of(
-                        "key", assetType,
+                        "name", assetType,
                         "value", assetId
                 );
 

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/services/AasService.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/services/AasService.java
@@ -527,8 +527,14 @@ public class AasService extends BaseService {
 
                 String jsonString = jsonUtil.toJson(assetIds, false);
                 HttpHeaders headers = this.getTokenHeader(edr);
+                headers.remove("Content-Type");         //  This should be fixed by the dtr team to allow content-type as application/json
                 params.put("assetIds", jsonString);
-                response = httpUtil.doGet(url, ArrayList.class, headers, params, true, false);
+                response = httpUtil.doGet(url, Map.class, headers, params, true, false);
+                if(response == null){
+                    return null;
+                }
+                Map<String,Object> responseBody = (Map<String,Object>) response.getBody();
+                return (ArrayList<String>) responseBody.get("result");
 
             } else {
                 // Query as GET if the central query is enabled
@@ -538,16 +544,15 @@ public class AasService extends BaseService {
                 );
 
                 String jsonString = jsonUtil.toJson(assetIds, false);
-                HttpHeaders headers = httpUtil.getHeadersWithToken(this.authService.getToken().getAccessToken());;
+                HttpHeaders headers = httpUtil.getHeadersWithToken(this.authService.getToken().getAccessToken());
                 params.put("assetIds", jsonString);
                 response = httpUtil.doGet(url, ArrayList.class, headers, params, true, false);
+                if(response == null){
+                    return null;
+                }
+                ArrayList<String> responseBody = (ArrayList<String>) response.getBody();
+                return responseBody;
             }
-            if(response == null){
-                return null;
-            }
-            ArrayList<String> responseBody = (ArrayList<String>) response.getBody();
-            return responseBody;
-
         } catch (Exception e) {
             throw new ServiceException(this.getClass().getName() + "." + "queryDigitalTwin",
                     e,

--- a/consumer-backend/productpass/src/main/resources/application.yml
+++ b/consumer-backend/productpass/src/main/resources/application.yml
@@ -68,7 +68,7 @@ configuration:
     dspEndpointKey: 'dspEndpoint'
     internalDtr: "https://materialpass.int.demo.catena-x.net/BPNL000000000000" # -- If there is an internal DTR available it can be referenced here and will be injected in the list of DTRs
     decentralApis:
-      search: "/lookup/shells/query"
+      search: "/lookup/shells"
       digitalTwin: "/shell-descriptors"
       subModel: "/submodel-descriptors"
     timeouts:


### PR DESCRIPTION
# Why we create this PR?
 
The registry lookup `lookup/shells/query` is no longer valid and changed to `/lookup/shells?assetIds=...`  after the registry hotfix update version `0.3.13-M1`.
 
# What we want to achieve with this PR?
 
The deprecated endpoint needs to be removed and replaced by new lookup API in order to comply with the latest registry version.
 
# What is new?
 
## Updated
- Updated registry endpoint `lookup/shells`

| Tickets |
| :---:   |
| [cmp-881](https://jira.catena-x.net/browse/CMP-881) |