### PR TITLE
Feature/cmp-1070/add timeToLive attribute : added timeToLive attribute to the discoveryfinder model

### DIFF
--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/catenax/Discovery.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/catenax/Discovery.java
@@ -25,6 +25,7 @@
 
 package org.eclipse.tractusx.digitalproductpass.models.catenax;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -34,6 +35,7 @@ import java.util.List;
  * This class consists exclusively to define attributes and methods related to discovering the needed Endpoints.
  **/
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Discovery {
 
     /** ATTRIBUTES **/
@@ -73,14 +75,17 @@ public class Discovery {
         String documentation;
         @JsonProperty("resourceId")
         String resourceId;
+        @JsonProperty("timeToLive")
+        String timeToLive;
 
         /** CONSTRUCTOR(S) **/
-        public Endpoint(String type, String description, String endpointAddress, String documentation, String resourceId) {
+        public Endpoint(String type, String description, String endpointAddress, String documentation, String resourceId, String timeToLive) {
             this.type = type;
             this.description = description;
             this.endpointAddress = endpointAddress;
             this.documentation = documentation;
             this.resourceId = resourceId;
+            this.timeToLive = timeToLive;
         }
         public Endpoint() {
         }
@@ -120,6 +125,14 @@ public class Discovery {
         @SuppressWarnings("Unused")
         public void setResourceId(String resourceId) {
             this.resourceId = resourceId;
+        }
+        @SuppressWarnings("Unused")
+        public String getTimeToLive() {
+            return timeToLive;
+        }
+        @SuppressWarnings("Unused")
+        public void setTimeToLive(String timeToLive) {
+            this.timeToLive = timeToLive;
         }
     }
 }


### PR DESCRIPTION
# Why we create this PR?
 
There is one new attribute `timeToLive` added to the discovery finder service which was not recognized by the backend system
 
# What we want to achieve with this PR?
 
To make backend work with the discovery finder service
 
# What is new?
 
## Updated
Added timeToLive attribute to the discovery service model

## PR Linked to:

<< If there is a ticket include it here >>

| Tickets |
| :---:   |
| [cmp-1070](https://jira.catena-x.net/browse/CMP-1070) |