### PR TITLE
Feature/cmp 1107/legal notice

### DIFF
--- a/.github/actions/setup-java/action.yaml
+++ b/.github/actions/setup-java/action.yaml
@@ -1,7 +1,8 @@
 #################################################################################
 # Catena-X - Product Passport Consumer Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -21,13 +22,13 @@
 #################################################################################
 
 ---
-name: "Setup Java 19"
-description: "Setup Java 19"
+name: "Setup Java"
+description: "Setup Java"
 runs:
   using: "composite"
   steps:
     - name: Setup Java
       uses: actions/setup-java@v4
       with:
-        java-version: '19'
-        distribution: 'adopt'
+        java-version: '21'
+        distribution: 'temurin'

--- a/.github/workflows/publish-dpp-backend-docker-image.yml
+++ b/.github/workflows/publish-dpp-backend-docker-image.yml
@@ -44,7 +44,6 @@ on:
 
 env:
   IMAGE_NAME: 'digital-product-pass-backend'
-  JAVA_VERSION: 19
   REGISTRY: 'ghcr.io'
   IMAGE_NAMESPACE: 'tractusx'
     
@@ -56,15 +55,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
+
+      - name: Setup Java
+        uses: ./.github/actions/setup-java
 
       # Build actions for GHCR registry
       - name: Docker meta for GHCR
         id: meta-for-ghcr
         if: ${{ github.repository != 'eclipse-tractusx/digital-product-pass' }}
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}
@@ -79,16 +81,11 @@ jobs:
       # https://github.com/docker/login-action
       - name: Log into GHCR registry
         if: ${{ github.repository != 'eclipse-tractusx/digital-product-pass' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions/setup-java@v3
-        with:
-          java-version: '${{ env.JAVA_VERSION }}'
-          distribution: 'adopt'
       
       # Build Java code with Maven
       - name:  Build dpp backend with maven for GHCR registry
@@ -102,7 +99,7 @@ jobs:
       - name: Build and push backend for GHCR registry
         id: build-and-push-backend-ghcr
         if: ${{ github.repository != 'eclipse-tractusx/digital-product-pass' }}
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: dpp-backend/digitalproductpass
           push: true
@@ -113,7 +110,7 @@ jobs:
       - name: Docker meta for Docker Hub
         id: meta-for-dockerhub
         if: ${{ github.repository == 'eclipse-tractusx/digital-product-pass' }}
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
@@ -128,15 +125,10 @@ jobs:
       # https://github.com/docker/login-action
       - name: Log into a Docker registry
         if: ${{ github.repository == 'eclipse-tractusx/digital-product-pass' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
-      - uses: actions/setup-java@v3
-        with:
-          java-version: '${{ env.JAVA_VERSION }}'
-          distribution: 'adopt'
       
       # Build Java code with Maven
       - name:  Build dpp backend with maven for Docker Hub
@@ -150,7 +142,7 @@ jobs:
       - name: Build and push backend for Docker Hub
         id: build-and-push-backend-dockerhub
         if: ${{ github.repository == 'eclipse-tractusx/digital-product-pass' }}
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: dpp-backend/digitalproductpass
           push: true
@@ -161,7 +153,7 @@ jobs:
       # Important step to push image description to DockerHub 
       - name: Update Docker Hub description
         if: ${{ github.repository == 'eclipse-tractusx/digital-product-pass' }}
-        uses: peter-evans/dockerhub-description@v3
+        uses: peter-evans/dockerhub-description@v4
         with:
         # readme-filepath defaults to toplevel README.md, Only necessary if you have a dedicated file with your 'Notice for docker images'   
           readme-filepath: docs/notice.md

--- a/.github/workflows/publish-dpp-backend-docker-image.yml
+++ b/.github/workflows/publish-dpp-backend-docker-image.yml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Pass Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -163,7 +164,7 @@ jobs:
         uses: peter-evans/dockerhub-description@v3
         with:
         # readme-filepath defaults to toplevel README.md, Only necessary if you have a dedicated file with your 'Notice for docker images'   
-        # readme-filepath: path/to/dedicated/notice-for-docker-image.md 
+          readme-filepath: docs/notice.md
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
           repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/publish-dpp-frontend-docker-image.yml
+++ b/.github/workflows/publish-dpp-frontend-docker-image.yml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Pass Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -145,7 +146,7 @@ jobs:
         uses: peter-evans/dockerhub-description@v3
         with:
         # readme-filepath defaults to toplevel README.md, Only necessary if you have a dedicated file with your 'Notice for docker images'   
-        # readme-filepath: path/to/dedicated/notice-for-docker-image.md 
+          readme-filepath: docs/notice.md
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
           repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/publish-dpp-frontend-docker-image.yml
+++ b/.github/workflows/publish-dpp-frontend-docker-image.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 
@@ -65,7 +65,7 @@ jobs:
       - name: Docker meta for GHCR
         id: meta-for-ghcr
         if: ${{ github.repository != 'eclipse-tractusx/digital-product-pass' }}
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}
@@ -80,7 +80,7 @@ jobs:
       # https://github.com/docker/login-action
       - name: Log into GHCR registry
         if: ${{ github.repository != 'eclipse-tractusx/digital-product-pass' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -91,7 +91,7 @@ jobs:
       - name: Build and push frontend for GHCR registry
         id: build-and-push-frontend-ghcr
         if: ${{ github.repository != 'eclipse-tractusx/digital-product-pass' }}
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: true
           tags: ${{ steps.meta-for-ghcr.outputs.tags }}, ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}:latest
@@ -104,7 +104,7 @@ jobs:
       - name: Docker meta for Docker Hub
         id: meta-for-dockerhub
         if: ${{ github.repository == 'eclipse-tractusx/digital-product-pass' }}
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
@@ -119,7 +119,7 @@ jobs:
       # https://github.com/docker/login-action
       - name: Log into a Docker registry
         if: ${{ github.repository == 'eclipse-tractusx/digital-product-pass' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
@@ -129,7 +129,7 @@ jobs:
       - name: Build and push frontend for Docker Hub
         id: build-and-push-frontend-dockerhub
         if: ${{ github.repository == 'eclipse-tractusx/digital-product-pass' }}
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: true
           tags: ${{ steps.meta-for-dockerhub.outputs.tags }}, ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
@@ -143,7 +143,7 @@ jobs:
       # Important step to push image description to DockerHub 
       - name: Update Docker Hub description
         if: ${{ github.repository == 'eclipse-tractusx/digital-product-pass' }}
-        uses: peter-evans/dockerhub-description@v3
+        uses: peter-evans/dockerhub-description@v4
         with:
         # readme-filepath defaults to toplevel README.md, Only necessary if you have a dedicated file with your 'Notice for docker images'   
           readme-filepath: docs/notice.md

--- a/README.md
+++ b/README.md
@@ -88,40 +88,30 @@ For installing the Digital Product Pass application please consult our [Intallat
 
 [Apache-2.0](https://raw.githubusercontent.com/eclipse-tractusx/digital-product-pass/main/LICENSE)
 
-## Notice for Docker images
-DockerHub:
 
+## Notice for Docker image
+
+DockerHub:
 - https://hub.docker.com/r/tractusx/digital-product-pass-frontend
 - https://hub.docker.com/r/tractusx/digital-product-pass-backend
 
-Eclipse Tractus-X product(s) installed within the image:
-
-- GitHub: https://github.com/eclipse-tractusx/digital-product-pass
-- Project home: https://projects.eclipse.org/projects/automotive.tractusx
-- Dockerfiles: 
-    - Frontend: https://github.com/eclipse-tractusx/digital-product-pass/blob/main/Dockerfile
-    - Backend: https://github.com/eclipse-tractusx/digital-product-pass/blob/main/dpp-backend/digitalproductpass/Dockerfile
-- Project License: [Apache License, Version 2.0](https://raw.githubusercontent.com/eclipse-tractusx/digital-product-pass/main/LICENSE)
-
-
-**Used base image**
-- [node:lts-alpine](https://github.com/nodejs/docker-node)
-- [nginxinc/nginx-unprivileged:stable-alpine](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/Dockerfile-alpine.template)
-- [eclipse-temurin:19-alpine](https://github.com/adoptium/containers)
-- Official DockerHub pages:
+**Base images:**
+- DockerHub:
     - Node: https://hub.docker.com/_/node
     - Nginxinc/nginx-unprivileged: https://hub.docker.com/r/nginxinc/nginx-unprivileged
-    - Eclipse Temurin: https://hub.docker.com/_/eclipse-temurin  
-- Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin  
-- Additional information about images:
+    - Eclipse Temurin: https://hub.docker.com/_/eclipse-temurin
+
+- Dockerfiles:
+    - [node:lts-alpine](https://github.com/nodejs/docker-node)
+    - [nginxinc/nginx-unprivileged:stable-alpine](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/Dockerfile-alpine.template)
+    - [eclipse-temurin:19-alpine](https://github.com/adoptium/containers)
+
+- GitHub project:
     - Node: https://github.com/docker-library/repo-info/tree/master/repos/node
-    - Nginxinc/nginx-unprivileged: https://github.com/nginxinc/docker-nginx-unprivileged
+    - nginxinc/docker-nginx-unprivileged: https://github.com/nginxinc/docker-nginx-unprivileged
     - Eclipse Temurin: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin
 
-As with all Docker images, these likely also contain other software which may be under other licenses 
-(such as Bash, etc. from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
 
-As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.
 
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->

--- a/docs/notice.md
+++ b/docs/notice.md
@@ -1,0 +1,57 @@
+<!--
+  Catena-X - Digital Product Pass Application
+ 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
+ 
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+ 
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  either express or implied. See the
+  License for the specific language govern in permissions and limitations
+  under the License.
+ 
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+## Notice for Docker images
+DockerHub:
+
+- https://hub.docker.com/r/tractusx/digital-product-pass-frontend
+- https://hub.docker.com/r/tractusx/digital-product-pass-backend
+
+Eclipse Tractus-X product(s) installed within the image:
+
+- GitHub: https://github.com/eclipse-tractusx/digital-product-pass
+- Project home: https://projects.eclipse.org/projects/automotive.tractusx
+- Dockerfiles: 
+    - Frontend: https://github.com/eclipse-tractusx/digital-product-pass/blob/main/Dockerfile
+    - Backend: https://github.com/eclipse-tractusx/digital-product-pass/blob/main/dpp-backend/digitalproductpass/Dockerfile
+- Project License: [Apache License, Version 2.0](https://raw.githubusercontent.com/eclipse-tractusx/digital-product-pass/main/LICENSE)
+
+
+**Used base image**
+- [node:lts-alpine](https://github.com/nodejs/docker-node)
+- [nginxinc/nginx-unprivileged:stable-alpine](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/Dockerfile-alpine.template)
+- [eclipse-temurin:19-alpine](https://github.com/adoptium/containers)
+- Official DockerHub pages:
+    - Node: https://hub.docker.com/_/node
+    - Nginxinc/nginx-unprivileged: https://hub.docker.com/r/nginxinc/nginx-unprivileged
+    - Eclipse Temurin: https://hub.docker.com/_/eclipse-temurin  
+- Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin  
+- Additional information about images:
+    - Node: https://github.com/docker-library/repo-info/tree/master/repos/node
+    - Nginxinc/nginx-unprivileged: https://github.com/nginxinc/docker-nginx-unprivileged
+    - Eclipse Temurin: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin
+
+As with all Docker images, these likely also contain other software which may be under other licenses 
+(such as Bash, etc. from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.


### PR DESCRIPTION
# Why we create this PR?
 
This PR contains the following changes:

- Worked on a new TRG diccussed here [TRG new: Docker file notice · Issue #360](https://github.com/eclipse-tractusx/sig-infra/issues/360)
- Added [notice.md](https://github.com/catenax-ng/tx-digital-product-pass/blob/feature/cmp-1107/legal-notice/docs/notice.md) to include "Notice for docker images" section to be only part of DockerHub description
- Updated Git actions versions in docker workflows and setup-java action
-  Updated "Notice for docker images" section in a root README.md file
- Refactor docker workflows

# What we want to achieve with this PR?
 
To be compliant with the TRG requirement [TRG-4.06](https://eclipse-tractusx.github.io/docs/release/trg-0/trg-4-06)
 
# What is new?
 
## Added
- Added notice.md to include "Notice for docker images" section to be only part of DockerHub description

## Updated
- Updated Git actions versions in docker workflows and setup-java action
-  Refactor docker workflows
- Updated "Notice for docker images" section in a main README.md

| Tickets |
| :---:   |
| [cmp-1107](https://jira.catena-x.net/browse/CMP-1107) |