### PR TITLE
Feature/cmp 1018/update ddtr version: Updated registry version to 0.3.31 

### DIFF
--- a/deployment/infrastructure/registry/Chart.yaml
+++ b/deployment/infrastructure/registry/Chart.yaml
@@ -26,12 +26,11 @@ name: registry
 description: Tractus-X Digital Twin Registry Helm Chart
 
 type: application
-version: 0.3.23
-#appVersion: 0.3.15-M1
+version: 0.3.31
 
 dependencies:
-  - name: registry
+  - name: digital-twin-registry
     repository: https://eclipse-tractusx.github.io/sldt-digital-twin-registry
     alias: provider-dtr
-    version: 0.3.23
+    version: 0.3.31
     condition: enabled

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/AasService.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/AasService.java
@@ -469,7 +469,7 @@ public class AasService extends BaseService {
                         "value", assetId
                 );
 
-                String jsonString = jsonUtil.toJson(assetIds, false);
+                String jsonString = CrypUtil.toBase64(jsonUtil.toJson(assetIds, false));
                 HttpHeaders headers = this.getTokenHeader(edr);
                 headers.remove("Content-Type");         //  This should be fixed by the dtr team to allow content-type as application/json
                 params.put("assetIds", jsonString);
@@ -487,7 +487,7 @@ public class AasService extends BaseService {
                         "value", assetId
                 );
 
-                String jsonString = jsonUtil.toJson(assetIds, false);
+                String jsonString = CrypUtil.toBase64(jsonUtil.toJson(assetIds, false));
                 HttpHeaders headers = httpUtil.getHeadersWithToken(this.authService.getToken().getAccessToken());
                 params.put("assetIds", jsonString);
                 response = httpUtil.doGet(url, ArrayList.class, headers, params, true, false);


### PR DESCRIPTION
# Why we create this PR?

This PR contains the following changes:
- Updated digital twin registry version to from 0.3.15-M1 to 0.3.31.
- Encrypted assetIds into base64 in  the dpp-backend
  
# What we want to achieve with this PR?
 
Updated the registry version to align with the current implementation changes.
 
# What is new?
 
## Updated
- Updated digital twin registry version to 0.3.31
- Encrypted assetIds into base64 in  the dpp-backend

## PR Linked to:


| Tickets |
| :---:   |
| [cmp-1018](https://jira.catena-x.net/browse/CMP-1018)  |
