### PR TITLE
chore(update): updated dpp testdata payload file: Adapted Industry Core changes

### DIFF
--- a/deployment/local/testing/testdata/testdata-payload.json
+++ b/deployment/local/testing/testdata/testdata-payload.json
@@ -1,40 +1,100 @@
 {
-  "policies": {
-    "@context": {
-      "odrl": "http://www.w3.org/ns/odrl/2/"
-    },
-    "@type": "PolicyDefinitionRequestDto",
-    "@id": "dpp-policy-id",
-    "policy": {
-      "@type": "Policy",
-      "odrl:permission": [
-        {
-          "odrl:action": "USE",
-          "odrl:constraint": {
-            "@type": "AtomicConstraint",
-            "odrl:or": [
-              {
-                "@type": "Constraint",
-                "odrl:leftOperand": "Membership",
-                "odrl:operator": {
-                  "@id": "odrl:eq"
+  "policies": [
+    {
+      "@context": {
+        "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+        "odrl": "http://www.w3.org/ns/odrl/2/",
+        "cx-policy": "https://w3id.org/catenax/policy/"
+      },
+      "@type": "PolicyDefinitionRequestDto",
+      "@id": "registry-policy",
+      "profile": "cx-policy:profile2405",
+      "policy": {
+        "@type": "Policy",
+        "@context": "http://www.w3.org/ns/odrl.jsonld",
+        "odrl:permission": [
+          {
+            "odrl:action": "USE",
+            "odrl:constraint": {
+              "@type": "LogicalConstraint",
+              "odrl:and": [
+                {
+                  "@type": "Constraint",
+                  "odrl:leftOperand": "Membership",
+                  "odrl:operator": {
+                    "@id": "odrl:eq"
+                  },
+                  "odrl:rightOperand": "active"
                 },
-                "odrl:rightOperand": "active"
-              },
-              {
-                "@type": "Constraint",
-                "odrl:leftOperand": "FrameworkAgreement.sustainability",
-                "odrl:operator": {
-                  "@id": "odrl:eq"
+                {
+                  "@type": "Constraint",
+                  "odrl:leftOperand": "BusinessPartnerNumber",
+                  "odrl:operator": {
+                    "@id": "odrl:eq"
+                  },
+                  "odrl:rightOperand": "BPNL00000007RVTB"
                 },
-                "odrl:rightOperand": "active"
-              }
-            ]
+                {
+                  "@type": "Constraint",
+                  "odrl:leftOperand": "cx-policy:UsagePurpose",
+                  "odrl:operator": {
+                    "@id": "odrl:eq"
+                  },
+                  "odrl:rightOperand": "cx.core.digitalTwinRegistry:1"
+                }
+              ]
+            }
           }
-        }
-      ]
+        ]
+      }
+    },
+    {
+      "@context": {
+        "odrl": "http://www.w3.org/ns/odrl/2/",
+        "cx-policy": "https://w3id.org/catenax/policy/"
+      },
+      "@type": "PolicyDefinitionRequestDto",
+      "@id": "dpp-policy-id",
+      "profile": "cx-policy:profile2405",
+      "policy": {
+        "@type": "Policy",
+        "odrl:permission": [
+          {
+            "odrl:action": "USE",
+            "odrl:constraint": {
+              "@type": "LogicalConstraint",
+              "odrl:and": [
+                {
+                  "@type": "Constraint",
+                  "odrl:leftOperand": "Membership",
+                  "odrl:operator": {
+                    "@id": "odrl:eq"
+                  },
+                  "odrl:rightOperand": "active"
+                },
+                {
+                  "@type": "Constraint",
+                  "odrl:leftOperand": "cx-policy:FrameworkAgreement",
+                  "odrl:operator": {
+                    "@id": "odrl:eq"
+                  },
+                  "odrl:rightOperand": "circulareconomy:1.0"
+                },
+                {
+                  "@type": "Constraint",
+                  "odrl:leftOperand": "cx-policy:UsagePurpose",
+                  "odrl:operator": {
+                    "@id": "odrl:eq"
+                  },
+                  "odrl:rightOperand": "cx.circular.dpp:1"
+                }
+              ]
+            }
+          }
+        ]
+      }
     }
-  },
+  ],
   "shells": [
     {
       "catenaXId": "urn:uuid:541ec5a5-9215-12f4-0803-94f456c947df",

--- a/deployment/local/testing/testdata/testdata-payload.json
+++ b/deployment/local/testing/testdata/testdata-payload.json
@@ -45,6 +45,16 @@
           "allowedBpns": ["BPNL00000007RVTB"]
         },
         {
+          "name": "manufacturerId",
+          "value": "BPNL00000007RVTB",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
+          "name": "digitalTwinType",
+          "value": "PartInstance",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
           "name": "manufacturerPartId",
           "value": "XYZ78901",
           "allowedBpns": ["BPNL00000007RVTB"]
@@ -354,6 +364,16 @@
         {
           "name": "partInstanceId",
           "value": "NCR186850B",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
+          "name": "manufacturerId",
+          "value": "BPNL00000007RVTB",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
+          "name": "digitalTwinType",
+          "value": "PartInstance",
           "allowedBpns": ["BPNL00000007RVTB"]
         },
         {
@@ -669,6 +689,16 @@
           "allowedBpns": ["BPNL00000007RVTB"]
         },
         {
+          "name": "manufacturerId",
+          "value": "BPNL00000007RVTB",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
+          "name": "digitalTwinType",
+          "value": "PartInstance",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
           "name": "manufacturerPartId",
           "value": "XYZ78901",
           "allowedBpns": ["BPNL00000007RVTB"]
@@ -978,6 +1008,16 @@
         {
           "name": "partInstanceId",
           "value": "Y792927456954B81677903848654570",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
+          "name": "digitalTwinType",
+          "value": "PartInstance",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
+          "name": "manufacturerId",
+          "value": "BPNL00000007RVTB",
           "allowedBpns": ["BPNL00000007RVTB"]
         },
         {
@@ -1397,6 +1437,16 @@
           "allowedBpns": ["BPNL00000007RVTB"]
         },
         {
+          "name": "manufacturerId",
+          "value": "BPNL00000007RVTB",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
+          "name": "digitalTwinType",
+          "value": "PartInstance",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
           "name": "partInstanceId",
           "value": "BAT-XYZ789",
           "allowedBpns": ["BPNL00000007RVTB"]
@@ -1433,6 +1483,20 @@
         {
           "name": "SerialPart",
           "data": {
+            "localIdentifiers": [
+              {
+                "value": "BPNL00000007RVTB",
+                "key": "manufacturerId"
+              },
+              {
+                "value": "XYZ78901",
+                "key": "manufacturerPartId"
+              },
+              {
+                "value": "BAT-XYZ789",
+                "key": "partInstanceId"
+              }
+            ],
             "partTypeInformation": {
               "classification": "product",
               "manufacturerPartId": "XYZ78901",
@@ -1570,7 +1634,7 @@
             "operation": {
               "importer": "BPNL000000000000",
               "manufacturer": {
-                "manufacturerId": "BPNL000000000000",
+                "manufacturerId": "BPNL00000007RVTB",
                 "facilityId": "BPNL000000000123"
               }
             }
@@ -1586,6 +1650,16 @@
         {
           "name": "manufacturerPartId",
           "value": "XYZ78901",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
+          "name": "manufacturerId",
+          "value": "BPNL00000007RVTB",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
+          "name": "digitalTwinType",
+          "value": "PartInstance",
           "allowedBpns": ["BPNL00000007RVTB"]
         },
         {
@@ -1625,6 +1699,24 @@
         {
           "name": "SerialPart",
           "data": {
+            "localIdentifiers": [
+              {
+                "value": "BPNL00000007RVTB",
+                "key": "manufacturerId"
+              },
+              {
+                "value": "XYZ78901",
+                "key": "manufacturerPartId"
+              },
+              {
+                "value": "EVMODULE-TRJ712",
+                "key": "partInstanceId"
+              }
+            ],
+            "manufacturingInformation": {
+              "date": "2022-02-04T14:48:54",
+              "country": "DEU"
+            },
             "partTypeInformation": {
               "classification": "component",
               "manufacturerPartId": "XYZ78901",
@@ -1790,6 +1882,16 @@
           "allowedBpns": ["BPNL00000007RVTB"]
         },
         {
+          "name": "manufacturerId",
+          "value": "BPNL00000007RVTB",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
+          "name": "digitalTwinType",
+          "value": "PartInstance",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
           "name": "partInstanceId",
           "value": "CTA-13123",
           "allowedBpns": ["BPNL00000007RVTB"]
@@ -1815,6 +1917,20 @@
         {
           "name": "SerialPart",
           "data": {
+            "localIdentifiers": [
+              {
+                "value": "BPNL00000007RVTB",
+                "key": "manufacturerId"
+              },
+              {
+                "value": "XYZ78901",
+                "key": "manufacturerPartId"
+              },
+              {
+                "value": "CTA-13123",
+                "key": "partInstanceId"
+              }
+            ],
             "partTypeInformation": {
               "classification": "component",
               "manufacturerPartId": "XYZ78901",
@@ -1977,6 +2093,16 @@
         {
           "name": "manufacturerPartId",
           "value": "XYZ78901",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
+          "name": "manufacturerId",
+          "value": "BPNL00000007RVTB",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
+          "name": "digitalTwinType",
+          "value": "PartInstance",
           "allowedBpns": ["BPNL00000007RVTB"]
         },
         {
@@ -2190,9 +2316,23 @@
         {
           "name": "SerialPart",
           "data": {
+            "localIdentifiers": [
+              {
+                "value": "BPNL00000007RVTB",
+                "key": "manufacturerId"
+              },
+              {
+                "value": "XYZ78901",
+                "key": "manufacturerPartId"
+              },
+              {
+                "value": "KLZ-90-8564-96",
+                "key": "partInstanceId"
+              }
+            ],
             "partTypeInformation": {
               "classification": "product",
-              "manufacturerPartId": "677-4.456-3434-K",
+              "manufacturerPartId": "XYZ78901",
               "nameAtManufacturer": "NMC111 Cathode"
             },
             "validityPeriod": {
@@ -2212,6 +2352,16 @@
         {
           "name": "manufacturerPartId",
           "value": "XYZ78901",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
+          "name": "manufacturerId",
+          "value": "BPNL00000007RVTB",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
+          "name": "digitalTwinType",
+          "value": "PartInstance",
           "allowedBpns": ["BPNL00000007RVTB"]
         },
         {
@@ -2375,6 +2525,16 @@
           "allowedBpns": ["BPNL00000007RVTB"]
         },
         {
+          "name": "manufacturerId",
+          "value": "BPNL00000007RVTB",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
+          "name": "digitalTwinType",
+          "value": "PartInstance",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
           "name": "partInstanceId",
           "value": "ABC123",
           "allowedBpns": ["BPNL00000007RVTB"]
@@ -2411,6 +2571,16 @@
         {
           "name": "manufacturerPartId",
           "value": "XYZ78901",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
+          "name": "manufacturerId",
+          "value": "BPNL00000007RVTB",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
+          "name": "digitalTwinType",
+          "value": "PartInstance",
           "allowedBpns": ["BPNL00000007RVTB"]
         },
         {
@@ -2729,6 +2899,16 @@
           "allowedBpns": ["BPNL00000007RVTB"]
         },
         {
+          "name": "manufacturerId",
+          "value": "BPNL00000007RVTB",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
+          "name": "digitalTwinType",
+          "value": "PartInstance",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
           "name": "partInstanceId",
           "value": "PRT-30001",
           "allowedBpns": ["BPNL00000007RVTB"]
@@ -2765,6 +2945,20 @@
         {
           "name": "SerialPart",
           "data": {
+            "localIdentifiers": [
+              {
+                "value": "BPNL00000007RVTB",
+                "key": "manufacturerId"
+              },
+              {
+                "value": "MFG024",
+                "key": "manufacturerPartId"
+              },
+              {
+                "value": "PRT-30001",
+                "key": "partInstanceId"
+              }
+            ],
             "partTypeInformation": {
               "classification": "product",
               "manufacturerPartId": "MFG024",
@@ -3085,6 +3279,16 @@
           "allowedBpns": ["BPNL00000007RVTB"]
         },
         {
+          "name": "digitalTwinType",
+          "value": "PartInstance",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
+          "name": "manufacturerId",
+          "value": "BPNL00000007RVTB",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
           "name": "manufacturerPartId",
           "value": "GP67890",
           "allowedBpns": ["BPNL00000007RVTB"]
@@ -3362,6 +3566,20 @@
         {
           "name": "SerialPart",
           "data": {
+            "localIdentifiers": [
+              {
+                "value": "BPNL00000007RVTB",
+                "key": "manufacturerId"
+              },
+              {
+                "value": "GP67890",
+                "key": "manufacturerPartId"
+              },
+              {
+                "value": "GR08-T789",
+                "key": "partInstanceId"
+              }
+            ],
             "partTypeInformation": {
               "classification": "component",
               "manufacturerPartId": "GP67890",
@@ -3384,6 +3602,16 @@
         {
           "name": "manufacturerPartId",
           "value": "MAT7814",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
+          "name": "manufacturerId",
+          "value": "BPNL00000007RVTB",
+          "allowedBpns": ["BPNL00000007RVTB"]
+        },
+        {
+          "name": "digitalTwinType",
+          "value": "PartInstance",
           "allowedBpns": ["BPNL00000007RVTB"]
         },
         {

--- a/deployment/local/testing/transform-and-upload.sh
+++ b/deployment/local/testing/transform-and-upload.sh
@@ -58,20 +58,25 @@ export SUBMODEL_ID=''
 
 source ./functions.sh
 
-POLICY=''
+DATA_POLICY=''
+REGISTRY_POLICY=''
+
+REGISTRY_POLICY=$(jq '.policies[0]' "${datapath}")
+DATA_POLICY=$(jq '.policies[1]' "${datapath}")
+
 # create edc assets, policies and contracts for the registry (DTR)
 echo "Creating default edc assets for the registry asset"
 create_registry_asset
+create_registry_policy "${REGISTRY_POLICY}"
+create_registry_contractdefinition
 create_default_policy
 create_default_contractdefinition
 echo
 
-POLICY=$(jq '.policies' "${datapath}")
-
 # create assets for passes
 echo "Creating edc assets for the passport"
 create_edc_asset
-create_edc_policy "${POLICY}"
+create_edc_policy "${DATA_POLICY}"
 create_contractdefinition
 echo
 

--- a/dpp-backend/digitalproductpass/README.md
+++ b/dpp-backend/digitalproductpass/README.md
@@ -21,7 +21,7 @@
   SPDX-License-Identifier: Apache-2.0
 -->
 
-<h1 style="display:flex; align-items: center;"><img src="../../docs/catena-x-logo.svg"/>&nbsp;&nbsp;Digital Product Pass Backend</h1>
+<h1 style="display:flex; align-items: center;"><img src="../../docs/media/catenaxLogo.svg"/>&nbsp;&nbsp;Digital Product Pass Backend</h1>
 
 
 <br>


### PR DESCRIPTION
# Why we create this PR?
 
This PR contains the following changes to the test data payload:
- Added `manufacturerId` and `digitalTwinType` attributes to the specificAssetIds in digital twin registry
- Added localIdentifiers to the `SerialPart` aspect model.
 
# What we want to achieve with this PR?
 
To be compliant with the latest Industry Core changes https://eclipse-tractusx.github.io/docs-kits/kits/Industry%20Core%20Kit/Software%20Development%20View/Digital%20Twins%20Development%20View%20Industry%20Core%20Kit
 
# What is new?
 
## Added
- Added the following Industry Core changes to the test data payload:
    - Added `manufacturerId` and `digitalTwinType` attributes to the specificAssetIds in digital twin registry
    - Added localIdentifiers to the `SerialPart` aspect model.

<!--
Include here the issues if available that will be closed with this PR.
Use the notation `Closes #<issueId>`
-->

| Tickets |
| :---:   |
| [cmp-1057](https://jira.catena-x.net/browse/CMP-1057) |
